### PR TITLE
Add start menu keyboard navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,13 +52,12 @@
 
   <div id="config-flow-screen" class="screen" style="display: flex;"> 
     <div class="config-main-panel"> 
-		<div id="splash-step" class="config-step active-step"> 
-			<p id="press-key-text">Press any key to start...</p>
-			<button id="initial-start-button">Start Game</button> 
-		    <div style="text-align: center; margin-top: 20px;">
-			  <button id="help-button" type="button">Game Summary</button>
-		    </div>			
-		</div>
+                <div id="splash-step" class="config-step active-step">
+                        <button id="initial-start-button">Start Game</button>
+                    <div style="text-align: center; margin-top: 20px;">
+                          <button id="help-button" type="button">Game Summary</button>
+                    </div>
+                </div>
 
       <div id="mode-step" class="config-step">
         <h3>Select Game Mode:</h3>

--- a/script.js
+++ b/script.js
@@ -117,6 +117,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const soundGameOver = new Audio('sounds/gameover.mp3');
   const soundbubblepop = new Audio('sounds/soundbubblepop.mp3');
   const soundLifeGained = new Audio('sounds/soundLifeGained.mp3');
+  const soundElectricShock = new Audio('sounds/electricshock.mp3');
   const container = document.getElementById('verb-buttons');
   const allBtns   = () => Array.from(container.querySelectorAll('.verb-button'));
 let currentConfigStep = 'splash'; // 'splash', 'mode', 'difficulty', 'details'
@@ -127,7 +128,6 @@ let provisionallySelectedOption = null; // Para guardar el botón antes de confi
 // Referencias a los nuevos elementos del DOM
 const configFlowScreen = document.getElementById('config-flow-screen');
 const splashStep = document.getElementById('splash-step');
-const pressKeyText = document.getElementById('press-key-text');
 const initialStartButton = document.getElementById('initial-start-button');
 
 const modeSelectionStep = document.getElementById('mode-step');
@@ -453,8 +453,8 @@ function navigateToStep(stepName) {
         if (configFlowScreenDiv) configFlowScreenDiv.classList.add('splash-active'); // Para que CSS pueda ocultar el panel derecho
         if (infoPanel) infoPanel.style.display = 'none'; // Ocultar explícitamente el panel derecho
         if (backButton) backButton.style.display = 'none';
-        document.addEventListener('keydown', handleInitialKeyPress);
-        if (initialStartButton) initialStartButton.disabled = false; 
+        if (initialStartButton) initialStartButton.disabled = false;
+        focusSplashButton(0);
         // No actualizamos el panel de info aquí si va a estar oculto.
         // El contenido por defecto del panel de info en el HTML se mostrará cuando sea visible.
 
@@ -477,8 +477,7 @@ function navigateToStep(stepName) {
         if (configFlowScreenDiv) configFlowScreenDiv.classList.remove('splash-active'); // Para que CSS pueda mostrar el panel derecho
         if (infoPanel) infoPanel.style.display = 'block'; // Mostrar explícitamente el panel derecho
         if (backButton) backButton.style.display = 'block'; 
-        document.removeEventListener('keydown', handleInitialKeyPress);
-        if (initialStartButton) initialStartButton.disabled = true; 
+        if (initialStartButton) initialStartButton.disabled = true;
 
         const modeInfoTitle = selectedMode ? (specificInfoData[configButtonsData[selectedMode]?.infoKey]?.title || selectedMode.replace(/_/g, ' ')) : "Not selected";
         const diffInfoTitle = selectedDifficulty ? (specificInfoData[configButtonsData[selectedDifficulty]?.infoKey]?.title || selectedDifficulty.replace(/_/g, ' ')) : "Not selected";
@@ -1470,20 +1469,38 @@ let usedVerbs = [];
 
 
         function handleInitialStart() {
-                if (soundClick) soundClick.play(); // Añadir sonido de clic si se desea
+                if (soundElectricShock) soundElectricShock.play();
                 if (initialStartButton) {
-                        initialStartButton.classList.add('selected');
-                        setTimeout(() => initialStartButton.classList.remove('selected'), 1000);
+                        initialStartButton.classList.add('electric-effect');
+                        setTimeout(() => initialStartButton.classList.remove('electric-effect'), 1000);
                 }
                 navigateToStep('mode');
         }
-	function handleInitialKeyPress(event) {
-		if (event.key) { // Cualquier tecla
-			 handleInitialStart();
-		}
-	}
-	initialStartButton.addEventListener('click', handleInitialStart);
-	document.addEventListener('keydown', handleInitialKeyPress);
+        const splashButtons = [initialStartButton, helpButton];
+        let currentSplashIndex = 0;
+        function focusSplashButton(i) {
+                if (!splashButtons[i]) return;
+                splashButtons.forEach(btn => btn.classList.remove('selected'));
+                const btn = splashButtons[i];
+                btn.classList.add('selected');
+                btn.focus();
+                currentSplashIndex = i;
+        }
+        function handleSplashNavigation(e) {
+                if (currentConfigStep !== 'splash') return;
+                if (e.key === 'ArrowDown') {
+                        e.preventDefault();
+                        focusSplashButton((currentSplashIndex + 1) % splashButtons.length);
+                } else if (e.key === 'ArrowUp') {
+                        e.preventDefault();
+                        focusSplashButton((currentSplashIndex - 1 + splashButtons.length) % splashButtons.length);
+                } else if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                        e.preventDefault();
+                        splashButtons[currentSplashIndex].click();
+                }
+        }
+        document.addEventListener('keydown', handleSplashNavigation);
+        initialStartButton.addEventListener('click', handleInitialStart);
 
 
 	// Inicializar botones de modo y dificultad

--- a/style.css
+++ b/style.css
@@ -1207,6 +1207,11 @@ button:active {
 #initial-start-button.selected,
 #help-button.selected {
   animation: splash-blink 1s infinite;
+  color: #ffffff !important;
+}
+
+#initial-start-button.electric-effect {
+  animation: electric-spark 0.5s infinite alternate;
 }
 
 @keyframes splash-blink {
@@ -2684,16 +2689,6 @@ body.is-loading .modal-backdrop:not(.specific-modal-backdrop) { /* :not para no 
     font-size: 2.5em; /* Más grande */
     color: var(--accent-color-blue);
     margin-bottom: 20px;
-}
-#press-key-text {
-    font-size: 1.5em;
-    color: var(--text-color);
-    margin-top: 30px;
-    animation: blink-text 1.5s infinite;
-}
-@keyframes blink-text {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.3; }
 }
 @keyframes pulse-border {
     0% { box-shadow: 0 0 5px rgba(255, 255, 100, 0.5); }


### PR DESCRIPTION
## Summary
- remove unused press-key text
- add start screen navigation with keyboard
- play electric shock when starting game
- tweak splash button styles

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684185f9671483278f45cc48629a9d44