### PR TITLE
Enable arrow navigation when confirming options

### DIFF
--- a/script.js
+++ b/script.js
@@ -1198,6 +1198,33 @@ function focusOption(buttonElement, container) {
     container.querySelectorAll('.config-flow-button').forEach(btn => btn.classList.remove('provisional-selection')); // Quitar otros parpadeos
     buttonElement.focus(); // Esto debería activar el listener de focus en initStepButtons
 }
+
+// Permite navegar con las flechas incluso cuando el botón de confirmar está enfocado
+function initConfirmButtonNavigation(confirmBtn, container) {
+    if (!confirmBtn || !container) return;
+
+    confirmBtn.addEventListener('keydown', (e) => {
+        const buttons = Array.from(container.querySelectorAll('.config-flow-button'));
+        if (!buttons.length) return;
+
+        if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+            e.preventDefault();
+            const currentIndex = buttons.indexOf(provisionallySelectedOption) >= 0 ?
+                                   buttons.indexOf(provisionallySelectedOption) : 0;
+            const nextButton = buttons[(currentIndex + 1) % buttons.length];
+            focusOption(nextButton, container);
+        } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+            e.preventDefault();
+            const currentIndex = buttons.indexOf(provisionallySelectedOption) >= 0 ?
+                                   buttons.indexOf(provisionallySelectedOption) : 0;
+            const prevButton = buttons[(currentIndex - 1 + buttons.length) % buttons.length];
+            focusOption(prevButton, container);
+        } else if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+            e.preventDefault();
+            confirmBtn.click();
+        }
+    });
+}
 function renderSetupRecords() {
   const container = document.getElementById('setup-records');
   if (!container) return;
@@ -1512,9 +1539,11 @@ let usedVerbs = [];
         initialStartButton.addEventListener('click', handleInitialStart);
 
 
-	// Inicializar botones de modo y dificultad
-	initStepButtons(gameModesContainer, 'mode');
-	initStepButtons(difficultyButtonsContainer, 'difficulty');
+        // Inicializar botones de modo y dificultad
+        initStepButtons(gameModesContainer, 'mode');
+        initStepButtons(difficultyButtonsContainer, 'difficulty');
+        initConfirmButtonNavigation(confirmModeButton, gameModesContainer);
+        initConfirmButtonNavigation(confirmDifficultyButton, difficultyButtonsContainer);
 
 	navigateToStep('splash'); // Empezar en el splash screen  
 function prepareNextQuestion() {


### PR DESCRIPTION
## Summary
- support keyboard arrows when confirm buttons have focus
- initialize confirm button navigation for mode and difficulty selectors

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68418f27c50c8327a3ed69a2ba80beaf