### PR TITLE
Add reflexive and accent toggle buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,6 @@
                   </button>
                 </div>
                 <div id="verb-groups-panel" class="groups-panel hidden">
-                  <button type="button" data-group="reflexive" class="group-button">Reflexive v.</button>
                   <button type="button" data-group="ar" class="group-button">-ar</button>
                   <button type="button" data-group="er" class="group-button">-er</button>
                   <button type="button" data-group="ir" class="group-button">-ir</button>
@@ -156,14 +155,16 @@
               </div>
             </div>
           </div>
+          <button type="button" id="toggle-reflexive" class="toggle-button">Reflexive Verbs</button>
+          <button type="button" id="toggle-ignore-accents" class="toggle-button selected" data-infokey="accentHelp">
+            Ignore Accents
+            <span class="context-info-icon" data-info-key="accentHelp"></span>
+          </button>
         </div>
         <div id="verb-irregularities-container">
           <p><strong>☠️Verb Irregularities☠️</strong></p>
           <div id="verb-type-buttons" class="verb-type-selector"></div>
         </div>
-        <label id="ignore-accents-label-container">
-          <input type="checkbox" id="ignore-accents" checked> Ignore accents (remember that accents give extra points)
-        </label>
       </div>
 
       <button id="back-button" style="display: none;">Back</button>

--- a/script.js
+++ b/script.js
@@ -40,6 +40,13 @@ function handleReflexiveToggle() {
     if (typeof soundClick !== 'undefined') soundClick.play();
 }
 
+function handleIgnoreAccentsToggle() {
+    const btn = document.getElementById('toggle-ignore-accents');
+    if (!btn) return;
+    btn.classList.toggle('selected');
+    if (typeof soundClick !== 'undefined') soundClick.play();
+}
+
 const soundClick = document.getElementById('sound-click');
 let openFilterDropdownMenu = null; // Para rastrear el menú de filtro abierto
 let tenseDropdownInitialized = false;
@@ -104,8 +111,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const enContainer  = document.getElementById('input-en-container');
   const feedback     = document.getElementById('feedback-area');
   const helpButton = document.getElementById('help-button'); 
-  const tooltip = document.getElementById('tooltip');   
+  const tooltip = document.getElementById('tooltip');
   const toggleReflexiveBtn = document.getElementById('toggle-reflexive');
+  const toggleIgnoreAccentsBtn = document.getElementById('toggle-ignore-accents');
   const titleElement = document.querySelector('.glitch-title');
   const verbTypeLabels = Array.from(document.querySelectorAll('label[data-times]'));
   const soundCorrect = new Audio('sounds/correct.mp3');
@@ -122,6 +130,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   const soundElectricShock = new Audio('sounds/electricshock.mp3');
   const container = document.getElementById('verb-buttons');
   const allBtns   = () => Array.from(container.querySelectorAll('.verb-button'));
+
+  if (toggleReflexiveBtn) {
+    toggleReflexiveBtn.addEventListener('click', handleReflexiveToggle);
+  }
+  if (toggleIgnoreAccentsBtn) {
+    toggleIgnoreAccentsBtn.addEventListener('click', handleIgnoreAccentsToggle);
+  }
 let currentConfigStep = 'splash'; // 'splash', 'mode', 'difficulty', 'details'
 let selectedMode = null;
 let selectedDifficulty = null;
@@ -2304,6 +2319,9 @@ function updateStreakForLifeDisplay() {
     if (reflexBtn) {
         reflexBtn.classList.remove('selected');
     }
+    if (toggleIgnoreAccentsBtn) {
+        toggleIgnoreAccentsBtn.classList.add('selected');
+    }
 
     navigateToStep('splash'); // Volver al inicio del flujo
     playHeaderIntro();
@@ -2342,7 +2360,7 @@ finalStartGameButton.addEventListener('click', async () => {
     currentOptions = {
         mode: selectedDifficulty, // Este es el modo de juego (receptive, productive_easy, productive)
         tenses: selTenses,
-        ignoreAccents: document.getElementById('ignore-accents').checked
+        ignoreAccents: toggleIgnoreAccentsBtn && toggleIgnoreAccentsBtn.classList.contains('selected')
     };
     // selectedGameMode ya debería estar seteado por el `selectedMode` de este nuevo flujo
     // Asegúrate de que `selectedGameMode` (variable global) se actualice con `selectedMode`
@@ -2603,7 +2621,12 @@ const specificInfoData = {
            <em>Example:</em> <span class="example-prompt-text">Present: to love – yo</span> You type:
            <div class="typing-animation-container"><div class="typing-animation" id="produce-example-anim"></div></div>
            <strong>Base Points:</strong> <span class="points-value">+15</span> per correct answer.<br>
-           <strong class="emphasis-mechanic">💖 Lives Mode Bonus:</strong> When playing in "Lives Mode", irregular or reflexive verbs in "Produce" have a <span class="emphasis-mechanic">~1 in 20</span> chance of being a 🎁 Prize Verb for an extra life!`
+          <strong class="emphasis-mechanic">💖 Lives Mode Bonus:</strong> When playing in "Lives Mode", irregular or reflexive verbs in "Produce" have a <span class="emphasis-mechanic">~1 in 20</span> chance of being a 🎁 Prize Verb for an extra life!`
+  },
+  accentHelp: {
+    title: "Ignore Accents",
+    html: `When this option is <strong>ON</strong>, you don't need to type accent marks to be correct.<br>
+           Leaving it <strong>OFF</strong> grants a <span class="points-value">+8</span> bonus each time you include the correct accents.`
   },
 };
 


### PR DESCRIPTION
## Summary
- move reflexive verb toggle outside dropdown and create ignore accent toggle
- hook both toggles up to game start options
- document accent toggle via new modal tooltip

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68418f99da7883278a31b299615a6096