### PR TITLE
Fix truncated records on splash screen

### DIFF
--- a/style.css
+++ b/style.css
@@ -2708,7 +2708,7 @@ body.is-loading .modal-backdrop:not(.specific-modal-backdrop) { /* :not para no 
 #config-flow-screen.splash-active .config-main-panel {
     width: 100%;
     border-right: none;
-    max-height: 400px;  /* Ejemplo */
+    max-height: 800px;  /* Más alto para mostrar los récords completos */
     /* O podrías hacer que el splash-step tenga un padding específico */
 }
 


### PR DESCRIPTION
## Summary
- enlarge record panel in splash screen to prevent truncation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684191e012048327bcaee0221fcdcd0c