### PR TITLE
Remove mobile volume slider

### DIFF
--- a/style.css
+++ b/style.css
@@ -585,7 +585,7 @@ button:active {
   animation: vibrate 0.3s infinite;
 }
 
- volume-slider{
+#volume-slider{
   appearance:none;
   height:4px;
   background:#666;
@@ -2758,6 +2758,11 @@ body.is-loading .modal-backdrop:not(.specific-modal-backdrop) { /* :not para no 
     #difficulty-buttons-container .config-flow-button {
         flex-basis: 100%;
         width: 100%;
+    }
+
+    /* Ocultar la barra de volumen en pantallas pequeñas */
+    #volume-slider {
+        display: none !important;
     }
 
 }


### PR DESCRIPTION
## Summary
- style volume slider using `#volume-slider`
- hide the volume bar when screen width is 600px or less

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68423d3459308327aa7ba2e16c591e23