### PR TITLE
Move Back button near Start Game

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
 
       <div id="details-step" class="config-step">
         <button id="final-start-game-button" class="start-button">Start Game</button>
+        <button id="back-button" style="display: none;">Back</button>
         <h3>Customize Your Game:</h3>
         <div id="filter-bar-container">
           <div class="filter-bar">
@@ -181,8 +182,6 @@
           <div id="verb-type-buttons" class="verb-type-selector"></div>
         </div>
       </div>
-
-      <button id="back-button" style="display: none;">Back</button>
 
     </div>
   </div> <div id="game-screen" class="screen" style="display: none;">


### PR DESCRIPTION
## Summary
- keep Back button visible when customizing by moving it inside the details step, just below **Start Game**

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68423d3fd73883279a846bf608619506