### PR TITLE
Use electric shock sound when confirming difficulty

### DIFF
--- a/script.js
+++ b/script.js
@@ -198,7 +198,7 @@ confirmModeButton.addEventListener('click', () => {
 
 confirmDifficultyButton.addEventListener('click', () => {
     if (provisionallySelectedOption) {
-        if (soundClick) soundClick.play();
+        if (soundElectricShock) soundElectricShock.play();
         selectedDifficulty = provisionallySelectedOption.dataset.mode;
 
         difficultyButtonsContainer.querySelectorAll('.config-flow-button').forEach(btn => {


### PR DESCRIPTION
## Summary
- change difficulty confirmation sound from click to electric shock

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68423d9583ac8327ab3445d6c6d1f4e1