### PR TITLE
Fix duplicate config buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,6 @@
                 <div id="verb-buttons" class="verb-buttons-list"></div>
               </div>
               </div>
-              <button type="button" id="toggle-reflexive" class="toggle-button">Reflexive Verbs</button>
             </div>
             <div id="pronoun-dropdown" class="dropdown">
               <button type="button" id="pronoun-dropdown-button" class="dropdown-toggle">
@@ -159,15 +158,15 @@
               </div>
             </div>
             <button type="button" id="toggle-ignore-accents" class="toggle-button selected" data-infokey="accentHelp">
+              <span class="tick"></span>
               Ignore Accents
               <span class="context-info-icon" data-info-key="accentHelp"></span>
             </button>
+            <div id="accent-help-text" class="help-text">
+              When ON, accents aren't required. Leaving it OFF awards <span class="points-value">+8</span> when used correctly.
+            </div>
           </div>
           <button type="button" id="toggle-reflexive" class="toggle-button">Reflexive Verbs</button>
-          <button type="button" id="toggle-ignore-accents" class="toggle-button selected" data-infokey="accentHelp">
-            Ignore Accents
-            <span class="context-info-icon" data-info-key="accentHelp"></span>
-          </button>
         </div>
         <div id="verb-irregularities-container">
           <p><strong>☠️Verb Irregularities☠️</strong></p>

--- a/script.js
+++ b/script.js
@@ -57,13 +57,6 @@ function handleIgnoreAccentsToggle() {
     if (typeof soundClick !== 'undefined') soundClick.play();
 }
 
-function handleIgnoreAccentsToggle() {
-    const btn = document.getElementById('toggle-ignore-accents');
-    if (!btn) return;
-    btn.classList.toggle('selected');
-    if (typeof soundClick !== 'undefined') soundClick.play();
-}
-
 const soundClick = document.getElementById('sound-click');
 let openFilterDropdownMenu = null; // Para rastrear el menú de filtro abierto
 let tenseDropdownInitialized = false;

--- a/style.css
+++ b/style.css
@@ -167,6 +167,41 @@ body::after {
   border: 1px solid var(--border-color);
 }
 
+#toggle-ignore-accents.toggle-button.selected {
+  background-color: var(--accent-color-red);
+  color: var(--title-color);
+  border: 1px solid var(--border-color);
+  animation: none;
+}
+
+#toggle-ignore-accents .tick {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  border: 1px solid var(--title-color);
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: 3px;
+  margin-right: 0.5em;
+  color: transparent;
+  flex-shrink: 0;
+}
+
+#toggle-ignore-accents.selected .tick::before {
+  content: '\2714';
+  color: var(--title-color);
+  font-size: 0.8em;
+  line-height: 1;
+  font-weight: bold;
+}
+
+#accent-help-text.help-text {
+  font-size: 0.85em;
+  margin-top: 4px;
+  color: var(--text-color);
+}
+
 @keyframes pulse-colors {
   0%   { box-shadow: 0 0 8px rgba(255,  0,   0, 0.8); }
   25%  { box-shadow: 0 0 8px rgba(255,165,   0, 0.8); }


### PR DESCRIPTION
## Summary
- remove stray reflexive and accent toggle buttons
- add persistent help text for accent toggle
- show a check mark when accents are ignored
- keep accent toggle red when selected
- clean up duplicate code in JS

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842432de8288327b0d3a9b802fb397a