### PR TITLE
Improve ranking display and move finish button

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,6 +233,7 @@
 	  
       <button id="check-button">Get Clue / Check Answer</button>
       <button id="skip-button">Skip</button>
+      <button id="end-button">Finish</button>
       <div id="feedback-area"></div>
 
       <div id="score-container">
@@ -242,7 +243,6 @@
       </div>
 
       <div id="ranking-box"></div>
-      <button id="end-button">Finish</button>
     </div>
   </div> <div id="left-bubbles"></div>
   <div id="right-bubbles"></div>

--- a/script.js
+++ b/script.js
@@ -208,6 +208,7 @@ confirmModeButton.addEventListener('click', () => {
         selectedMode = provisionallySelectedOption.dataset.mode;
         window.selectedGameMode = selectedMode;
         selectedGameMode = selectedMode; // Mantener sincronizado el modo seleccionado
+        updateRanking();
 
         gameModesContainer.querySelectorAll('.config-flow-button').forEach(btn => {
             btn.classList.remove('provisional-selection');
@@ -1500,11 +1501,13 @@ function applyIrregularityAndTenseFiltersToVerbList() {
 }
   function updateRanking() {
     rankingBox.innerHTML = '<h3>🏆 Top 5</h3>';
-  
+    const mode = selectedGameMode || window.selectedGameMode;
+    if (!mode) return;
+
     db.collection("records")
-      .where("mode", "==", selectedGameMode)
+      .where("mode", "==", mode)
       .orderBy("score", "desc")
-      .limit(10)
+      .limit(5)
       .get()
       .then(snapshot => {
         snapshot.forEach(doc => {
@@ -1515,7 +1518,7 @@ function applyIrregularityAndTenseFiltersToVerbList() {
     .catch((error) => {
       console.error("Error loading rankings:", error);
     });
-  } 
+  }
 
   function updateScore() {
     scoreDisplay.innerHTML =
@@ -2443,7 +2446,7 @@ finalStartGameButton.addEventListener('click', async () => {
     score = 0; streak = 0; multiplier = 1.0; bestStreak = 0; // Resetear bestStreak también
     updateScore();
     // updateGameTitle(); // Ya debería tener selectedDifficulty y selTenses
-    // updateRanking(); // Si aplica
+    updateRanking();
 
     const livesMechanicsDisplay = document.getElementById('lives-mechanics-display');
     if (window.selectedGameMode === 'lives') { // Usar window.selectedGameMode que se actualizó
@@ -2536,7 +2539,8 @@ function checkFinalStartButtonState() {
                 db.collection("records").add(recordData)
                   .then(() => {
                     console.log("Record saved online!");
-                    renderSetupRecords(); 
+                    renderSetupRecords();
+                    updateRanking();
                   })
                   .catch(error => {
                     console.error("Error saving record (endButton):", error);


### PR DESCRIPTION
## Summary
- move Finish button next to Skip
- load top 5 rankings for the selected mode
- refresh ranking when a mode is chosen, at game start, and after saving a record

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684245ab38e883278124aa7983e7abb7