### PR TITLE
Improve footer visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -1146,7 +1146,8 @@ button:active {
   gap: 10px;
   text-align: center;
   font-size: 0.8em;
-  color: #888;            /* un gris discreto */
+  color: #ddd;            /* más claro para mayor contraste */
+  text-shadow: 0 0 6px rgba(0, 0, 0, 0.8);
   margin: 30px auto 10px;
 }
 .game-footer .feedback-link {
@@ -1155,26 +1156,31 @@ button:active {
   padding: 4px 8px;
   border: 1px solid var(--accent-color-blue);
   border-radius: 4px;
-  transition: background-color 0.2s;
+  text-shadow: 0 0 4px rgba(255, 255, 255, 0.9);
+  filter: brightness(1.3);
+  transition: background-color 0.2s, filter 0.2s;
 }
 .game-footer .feedback-link:hover {
   background-color: rgba(255,255,255,0.1);
+  filter: brightness(1.5);
 }
 
 /* Buy Me a Coffee button */
 .game-footer .coffee-link {
-  color: #fffbcc; /* light gold */
+  color: #8b0000; /* dark red text for contrast */
   text-decoration: none;
   padding: 4px 8px;
-  border: 1px solid #d4af37; /* golden border */
+  border: 1px solid #8b0000; /* matching dark red border */
   border-radius: 4px;
-  background: linear-gradient(45deg, #d4af37, #fffbcc);
-  box-shadow: 0 0 5px rgba(212, 175, 55, 0.7);
+  background: linear-gradient(45deg, #ffe5e5, #fffafa);
+  box-shadow: 0 0 5px rgba(139, 0, 0, 0.4);
+  text-shadow: 0 0 4px rgba(255, 255, 255, 0.9);
+  filter: brightness(1.2);
   transition: box-shadow 0.2s, filter 0.2s;
 }
 .game-footer .coffee-link:hover {
-  box-shadow: 0 0 8px rgba(255, 215, 0, 1);
-  filter: brightness(1.1);
+  box-shadow: 0 0 8px rgba(139, 0, 0, 0.8);
+  filter: brightness(1.3);
 }
 #left-bubbles, #right-bubbles {
   position: fixed;


### PR DESCRIPTION
## Summary
- brighten and add halo for footer text and links
- tweak "Support the Game" button with a red color scheme for better contrast

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6842560a0c848327b82b4637f190ef9e