### PR TITLE
Add electric effects and fade out on finish

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
 	  
       <button id="check-button">Get Clue / Check Answer</button>
       <button id="skip-button">Skip</button>
-      <button id="end-button">Finish</button>
+      <button id="end-button">END GAME</button>
       <div id="feedback-area"></div>
 
       <div id="score-container">

--- a/script.js
+++ b/script.js
@@ -270,6 +270,8 @@ confirmModeButton.addEventListener('click', () => {
 confirmDifficultyButton.addEventListener('click', () => {
     if (provisionallySelectedOption) {
         if (soundElectricShock) soundElectricShock.play();
+        confirmDifficultyButton.classList.add('electric-effect');
+        setTimeout(() => confirmDifficultyButton.classList.remove('electric-effect'), 1000);
         selectedDifficulty = provisionallySelectedOption.dataset.mode;
 
         difficultyButtonsContainer.querySelectorAll('.config-flow-button').forEach(btn => {
@@ -2118,10 +2120,10 @@ function checkAnswer() {
       })
       .then(() => {
         console.log("Record saved online!");
-		renderSetupRecords(); 
-		quitToSettings();
+                renderSetupRecords();
       })
-      .catch(error => console.error("Error saving record:", error));
+      .catch(error => console.error("Error saving record:", error))
+      .then(() => fadeOutToMenu(quitToSettings));
 	}
 	   return; 
 
@@ -2239,10 +2241,11 @@ function startTimerMode() {
           console.log("Record saved online!");
           renderSetupRecords();
         })
-        .catch(error => console.error("Error saving record:", error));
+        .catch(error => console.error("Error saving record:", error))
+        .then(() => fadeOutToMenu(quitToSettings));
+      } else {
+        fadeOutToMenu(quitToSettings);
       }
-
-      quitToSettings();
     }
   }, 1000);
 }
@@ -2382,7 +2385,7 @@ function updateStreakForLifeDisplay() {
   el.innerHTML = `🔥 <span class="math-inline">${remaining}</span> to get 1❤️`;
 }
 
- function quitToSettings() {
+function quitToSettings() {
   document.getElementById('timer-container').style.display = 'none';
   clearInterval(countdownTimer);
   gameMusic.pause();
@@ -2433,6 +2436,18 @@ function updateStreakForLifeDisplay() {
     navigateToStep('splash'); // Volver al inicio del flujo
     playHeaderIntro();
     checkFinalStartButtonState(); // Para el estado inicial del botón
+}
+
+function fadeOutToMenu(callback) {
+  const screen = document.getElementById('game-screen');
+  if (!screen) { callback(); return; }
+  screen.classList.add('fade-out');
+  const handler = () => {
+    screen.classList.remove('fade-out');
+    screen.removeEventListener('animationend', handler);
+    callback();
+  };
+  screen.addEventListener('animationend', handler);
 }
     updateRanking();
     remainingLives = 5;
@@ -2567,6 +2582,9 @@ function checkFinalStartButtonState() {
     if (skipButton) skipButton.addEventListener('click', skipQuestion);
     if (endButton) {
         endButton.addEventListener('click', () => {
+            if (soundElectricShock) soundElectricShock.play();
+            endButton.classList.add('electric-effect');
+            setTimeout(() => endButton.classList.remove('electric-effect'), 1000);
             const name = prompt('¿Cómo te llamas?'); // La variable name debe ser local a este scope
             if (name) {
                 const recordData = {
@@ -2587,9 +2605,11 @@ function checkFinalStartButtonState() {
                   })
                   .catch(error => {
                     console.error("Error saving record (endButton):", error);
-                  });
+                  })
+                  .then(() => fadeOutToMenu(quitToSettings));
+            } else {
+                fadeOutToMenu(quitToSettings);
             }
-            quitToSettings(); // quitToSettings debe estar definida
         });
     }
 

--- a/style.css
+++ b/style.css
@@ -1305,6 +1305,14 @@ button:active {
   animation: electric-spark 0.5s infinite alternate;
 }
 
+#confirm-difficulty-button.electric-effect {
+  animation: electric-spark 0.5s infinite alternate;
+}
+
+#end-button.electric-effect {
+  animation: electric-spark 0.5s infinite alternate;
+}
+
 @keyframes splash-blink {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.3; }
@@ -1681,7 +1689,10 @@ button:active {
 }
 
 #final-start-game-button:hover,
-.start-button:hover {
+.start-button:hover,
+#confirm-mode-button:hover,
+#confirm-difficulty-button:hover,
+#end-button:hover {
   animation: electric-spark 0.5s infinite alternate;
 }
 
@@ -2787,6 +2798,13 @@ body.is-loading .modal-backdrop:not(.specific-modal-backdrop) { /* :not para no 
     overflow: hidden;
     /* ... otros estilos de tus botones principales ... */
 }
+#end-button {
+    background-color: #902020;
+}
+
+#end-button:hover {
+    background-color: #a03030;
+}
 #final-start-game-button:disabled {
     background-color: #555;
     cursor: not-allowed;
@@ -2886,4 +2904,13 @@ body.is-loading .modal-backdrop:not(.specific-modal-backdrop) { /* :not para no 
         display: none !important;
     }
 
+}
+
+.fade-out {
+    animation: fadeOutScreen 1s forwards;
+}
+
+@keyframes fadeOutScreen {
+    from { opacity: 1; }
+    to { opacity: 0; }
 }


### PR DESCRIPTION
## Summary
- update finish button label
- use electric-spark animation on confirm & finish buttons
- darken finish button styling
- add fade-out screen transition when saving records

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6842662a1ad0832781cff5ba80eed2ae