### PR TITLE
Add fade-in intro on first splash

### DIFF
--- a/script.js
+++ b/script.js
@@ -438,6 +438,13 @@ backButton.addEventListener('click', () => {
 };
 window.addEventListener("load", () => {
   document.body.classList.remove("is-loading");
+  if (!localStorage.getItem('introPlayed')) {
+    document.body.classList.add('fade-in');
+    document.body.addEventListener('animationend', () => {
+      document.body.classList.remove('fade-in');
+    }, { once: true });
+    localStorage.setItem('introPlayed', 'true');
+  }
 });
 
 const pronounGroups = [

--- a/style.css
+++ b/style.css
@@ -2914,3 +2914,13 @@ body.is-loading .modal-backdrop:not(.specific-modal-backdrop) { /* :not para no 
     from { opacity: 1; }
     to { opacity: 0; }
 }
+
+/* Fade in effect for first-time splash */
+.fade-in {
+    animation: fadeInScreen 1s forwards;
+}
+
+@keyframes fadeInScreen {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- add fade-in animation styles for the splash
- trigger fade-in once on first load using localStorage

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68426d9b87dc8327985df0beeb7af37d