### PR TITLE
Fix ignore accents checkbox layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -180,6 +180,15 @@ body::after {
   animation: none;
 }
 
+#toggle-ignore-accents {
+  position: relative;
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  padding-left: 4px;
+  padding-right: 28px; /* space for the info icon */
+}
+
 #toggle-ignore-accents .tick {
   display: inline-flex;
   align-items: center;
@@ -189,7 +198,7 @@ body::after {
   border: 1px solid var(--title-color);
   background-color: rgba(0, 0, 0, 0.2);
   border-radius: 3px;
-  margin-right: 0.5em;
+  margin-right: 0.3em;
   color: transparent;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- adjust ignore accents toggle layout so label stays on one line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68429254e2308327978e88f5cdf54dc9