### PR TITLE
Fix broken CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -184,6 +184,7 @@ body::after {
 #toggle-reflexive {
   position: relative;
   padding-right: 28px;
+}
 
 #toggle-ignore-accents {
   position: relative;
@@ -1510,14 +1511,6 @@ button:active {
 
 
 
-    /*#help-button {
-       position: static;
-       transform: none;
-       margin: 8px 0 16px 0; /* Remove margin-left: auto if it's in a column */
-       /*width: 8%; /* To match other buttons that become full-width */
-       /* align-self: initial; /* Or stretch, depending on how you want it in column */
-    }
- }
 
 
  body.tooltip-open-no-scroll {
@@ -1719,7 +1712,6 @@ button:active {
 	box-sizing: border-box !important;
 	margin-bottom: 0 !important;
   }
-}
   #tooltip .tooltip-box h5 {
     font-size: 1.1em !important; /* Ajustar tamaño del título */
     margin-bottom: 8px !important;
@@ -1760,7 +1752,6 @@ button:active {
     padding: 8px 12px !important;
     margin-top: 10px !important;
  }
-}
 
  @keyframes electric-spark {
   0%   { box-shadow: 0 0 2px #ffea00, 0 0 5px #ffea00; }


### PR DESCRIPTION
## Summary
- close `#toggle-reflexive` block
- remove stray comment blocks
- fix mismatched braces in tooltip CSS

## Testing
- `node - <<'EOF'
const fs=require('fs');
let data=fs.readFileSync('style.css','utf8');
let stack=[];let err=false;let lines=data.split(/\r?\n/);for(let i=0;i<lines.length;i++){for(const ch of lines[i]){if(ch=='{')stack.push(i+1);if(ch=='}'){if(stack.length==0){console.log('Unmatched } at line',i+1);err=true;}else stack.pop();}}}if(stack.length){console.log(stack.length+' unmatched { starting at lines '+stack.join(','));err=true;}if(!err)console.log('All braces balanced');
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6842a49740f88327aef8b8c624aefcad