### PR TITLE
Fix mobile dark border

### DIFF
--- a/style.css
+++ b/style.css
@@ -59,7 +59,8 @@ body::before {
   width: 100%;
   height: 100%;
   box-shadow: inset 0 0 100px 30px rgba(0, 0, 0, 0.85);
-  border-radius: 50px;
+  /* Use the same radius as the body to avoid visible gaps on mobile */
+  border-radius: 20px;
   pointer-events: none;
   z-index: 3;
 }


### PR DESCRIPTION
## Summary
- match the overlay's border radius to the body element so it covers the full left edge on phones

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684634db47a483278e4ac9cbf5c35ec7