### PR TITLE
Fix ticking sound triggering in non-timer modes

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,6 +84,16 @@ document.addEventListener('DOMContentLoaded', async () => {
   let tickingSoundPlaying = false;
 
   function checkTickingSound() {
+    // Only relevant in timer mode; ensure sound doesn't play in other modes
+    if (selectedGameMode !== 'timer') {
+      if (tickingSoundPlaying) {
+        soundTicking.pause();
+        soundTicking.currentTime = 0;
+        tickingSoundPlaying = false;
+      }
+      return;
+    }
+
     if (timerTimeLeft <= 10) {
       if (!tickingSoundPlaying) {
         soundTicking.currentTime = 0;


### PR DESCRIPTION
## Summary
- prevent ticking sound from playing in infinite/lives modes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68463a78ff3883278451053efced8ceb