### PR TITLE
Add tooltip access for game mode and tense badges

### DIFF
--- a/script.js
+++ b/script.js
@@ -2810,13 +2810,19 @@ function updateGameTitle() {
     'productive': '⌨️Pr0duc€⌨️'
   };
 
-  const tenseNames = currentOptions.tenses.map(t => t.replace('_', ' '));
+  const tenseObjs = currentOptions.tenses.map(tKey => {
+    const obj = tenses.find(t => t.value === tKey);
+    return { key: tKey, name: obj ? obj.name : tKey.replace('_', ' '), infoKey: obj?.infoKey || '' };
+  });
+  const tenseNames = tenseObjs.map(o => o.name);
   const displayMode = modeLabels[currentOptions.mode] || currentOptions.mode;
 
-  const modeBtn = `<span class="mode-badge ${currentOptions.mode}">${displayMode}</span>`;
-  const tenseBtns = tenseNames.map(t => {
-    const cls = 'tense-badge ' + t.replace(/\s+/g, '_');
-    return `<span class="${cls}">${t}</span>`;
+  const modeInfoKey = configButtonsData[currentOptions.mode]?.infoKey || '';
+  const modeBtn = `<span class="mode-badge ${currentOptions.mode}" data-info-key="${modeInfoKey}">${displayMode}</span>`;
+
+  const tenseBtns = tenseObjs.map(o => {
+    const cls = 'tense-badge ' + o.key.replace(/\s+/g, '_');
+    return `<span class="${cls}" data-info-key="${o.infoKey}">${o.name}</span>`;
   }).join(' ');
 
   let html = `
@@ -2839,6 +2845,25 @@ function updateGameTitle() {
   }
 
   gameTitle.innerHTML = html;
+
+  const modeBadgeEl = gameTitle.querySelector('.mode-badge');
+  if (modeBadgeEl && modeBadgeEl.dataset.infoKey) {
+    modeBadgeEl.addEventListener('click', () => {
+      if (typeof soundClick !== 'undefined') soundClick.play();
+      openSpecificModal(modeBadgeEl.dataset.infoKey);
+    });
+  }
+
+  const tenseBadgeEls = gameTitle.querySelectorAll('.tense-badge');
+  tenseBadgeEls.forEach(tb => {
+    const key = tb.dataset.infoKey;
+    if (key) {
+      tb.addEventListener('click', () => {
+        if (typeof soundClick !== 'undefined') soundClick.play();
+        openSpecificModal(key);
+      });
+    }
+  });
 }
 
 function typewriterEffect(textElement, text, interval) {

--- a/style.css
+++ b/style.css
@@ -439,8 +439,8 @@ button:active {
 
 .mode-badge,
 .tense-badge {
-    pointer-events: none;
-    cursor: default;
+    pointer-events: auto;
+    cursor: help;
 }
 
 .tense-badge.present { background-color: transparent; border-color: #aaa; color: #aaa; }


### PR DESCRIPTION
## Summary
- display mode and tense badges with `data-info-key`
- open the existing modal with info when badges are clicked
- allow clicking badges by enabling pointer events

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684643976f4483278a9cbe7b9f6c1d9c