### PR TITLE
Add tooltip icons for mode and tense badges

### DIFF
--- a/script.js
+++ b/script.js
@@ -2830,11 +2830,11 @@ function updateGameTitle() {
   const displayMode = modeLabels[currentOptions.mode] || currentOptions.mode;
 
   const modeInfoKey = configButtonsData[currentOptions.mode]?.infoKey || '';
-  const modeBtn = `<span class="mode-badge ${currentOptions.mode}" data-info-key="${modeInfoKey}">${displayMode}</span>`;
+  const modeBtn = `<span class="mode-badge ${currentOptions.mode}" data-info-key="${modeInfoKey}">${displayMode}<span class="context-info-icon" data-info-key="${modeInfoKey}"></span></span>`;
 
   const tenseBtns = tenseObjs.map(o => {
     const cls = 'tense-badge ' + o.key.replace(/\s+/g, '_');
-    return `<span class="${cls}" data-info-key="${o.infoKey}">${o.name}</span>`;
+    return `<span class="${cls}" data-info-key="${o.infoKey}">${o.name}<span class="context-info-icon" data-info-key="${o.infoKey}"></span></span>`;
   }).join(' ');
 
   let html = `

--- a/style.css
+++ b/style.css
@@ -424,6 +424,8 @@ button:active {
     color: #fff;
     background-color: #333;
     text-shadow: 1px 1px 2px #000;
+    position: relative;
+    padding-right: 24px;
 }
 .mode-badge.receptive { background-color: #dc3545; }
 .mode-badge.productive_easy { background-color: #6f42c1; }
@@ -441,6 +443,8 @@ button:active {
     color: #fff;
     background-color: #333;
     text-shadow: 1px 1px 2px #000;
+    position: relative;
+    padding-right: 24px;
 }
 
 .mode-badge,


### PR DESCRIPTION
## Summary
- show tooltip icon inside game mode and tense badges
- style badges to reserve space for the new icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684645c424b48327a86058e2f4617439