### PR TITLE
Improve record display

### DIFF
--- a/script.js
+++ b/script.js
@@ -1411,10 +1411,10 @@ function renderSetupRecords() {
             <div class="record-item">
               <span class="medal">${medal}</span>
               <strong>${name}:</strong> ${score} pts
-              <span class="record-date">${dateStr}</span>
               ${streak
-                ? `<span class="record-streak">· Max🔥: ${streak}</span>`
+                ? `<span class="record-streak">🔥${streak}</span>`
                 : ''}
+              <span class="record-date">${dateStr}</span>
             </div>
           `;
           ul.appendChild(li);

--- a/style.css
+++ b/style.css
@@ -886,6 +886,17 @@ button:active {
 .mode-records .record-list li {
   margin: 6px 0;
 }
+
+/* Estilo para cada entrada de récord */
+.record-item {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.record-date {
+  font-size: 0.75em;
+}
 @keyframes vibrate {
   0%   { transform: translate(0); }
   20%  { transform: translate(-1px, 1px); }


### PR DESCRIPTION
## Summary
- tweak HTML structure when showing high scores
- style record items and show date in smaller font

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68464b01f238832781f23e28d59412a9