### PR TITLE
Fix Chuache missing on menu screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,11 +33,12 @@
 
   <header class="main-header">
           <img loading="lazy" src="images/conjucityhk.webp" class="header-city" alt="city"/>
-	  <h1 class="glitch-title">
-		<span class="big-letter">T</span>HE 
-		<span class="big-letter">C</span>ONJUGATOR
-	  </h1>
-	</header>
+          <img loading="lazy" src="images/conjuchuache.webp" class="header-char" alt="char"/>
+          <h1 class="glitch-title">
+                <span class="big-letter">T</span>HE
+                <span class="big-letter">C</span>ONJUGATOR
+          </h1>
+        </header>
 
   <div class="music-controls">
     <button id="music-toggle" class="music-button" title="Toggle music">


### PR DESCRIPTION
## Summary
- restore `<img class="header-char">` to show Chuache on the splash and mode screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846618500fc832784eeb03a7fc5cb98