### PR TITLE
Update error speech color

### DIFF
--- a/script.js
+++ b/script.js
@@ -61,12 +61,15 @@ function chuacheSpeaks(type) {
   image.src = "images/chuachetalks.gif";
   bubble.textContent = message;
   bubble.classList.remove("hidden");
+  if (type === "wrong") bubble.classList.add("error");
+  else bubble.classList.remove("error");
 
   playFromStart(chuacheSound);
 
   setTimeout(() => {
     image.src = "images/conjuchuache.webp";
     bubble.classList.add("hidden");
+    bubble.classList.remove("error");
   }, 2000);
 }
 

--- a/style.css
+++ b/style.css
@@ -3173,6 +3173,12 @@ td.irregular-highlight {
   left: -20px;
 }
 
+.speech-bubble.error {
+  background: #330000;
+  border-color: #ff5555;
+  color: #ff5555;
+}
+
 .speech-bubble.hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary
- add `.speech-bubble.error` style for reddish background, border, and text
- toggle `.error` class when Chuache complains about wrong answers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68466604ad00832784bff24abe794b99