### PR TITLE
Add themed name entry modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,17 @@
     </div>
     <button id="close-specific-modal-btn" class="specific-modal-close-btn">&times;</button>
   </div>
-  <div class="modal-backdrop"></div> 
+  <div id="name-modal-backdrop" class="specific-modal-backdrop"></div>
+  <div id="name-entry-modal" class="specific-modal">
+    <div class="specific-modal-content">
+      <h2 id="name-modal-title">🏆 New Record! 🏆</h2>
+      <p id="name-entry-message">Enter your name:</p>
+      <input type="text" id="player-name-input" maxlength="20" autocomplete="off" />
+      <button id="name-submit-button" class="start-button name-submit">Submit</button>
+    </div>
+    <button id="close-name-modal-btn" class="specific-modal-close-btn">&times;</button>
+  </div>
+  <div class="modal-backdrop"></div>
   <div id="tooltip" class="tooltip-popup"></div>
 
   <header class="main-header">

--- a/script.js
+++ b/script.js
@@ -2387,25 +2387,26 @@ function startTimerMode() {
           chuacheSpeaks('gameover');
       clearInterval(countdownTimer);
   
-      const name = prompt('⏱️ Time is up! Your name?');
-      if (name) {
-        db.collection("records").add({
-          name: name,
-          score: score,
-          mode: selectedGameMode,
-          timestamp: firebase.firestore.FieldValue.serverTimestamp(),
-          tense: currentOptions.tenses,
-          verb: currentQuestion.verb.infinitive_es,
-          streak: bestStreak
-        })
-        .then(() => {
-          renderSetupRecords();
-        })
-        .catch(error => console.error("Error saving record:", error))
-        .then(() => fadeOutToMenu(quitToSettings));
-      } else {
-        fadeOutToMenu(quitToSettings);
-      }
+      openNameModal('⏱️ Time is up! Your name?', function(name) {
+        if (name) {
+          db.collection("records").add({
+            name: name,
+            score: score,
+            mode: selectedGameMode,
+            timestamp: firebase.firestore.FieldValue.serverTimestamp(),
+            tense: currentOptions.tenses,
+            verb: currentQuestion.verb.infinitive_es,
+            streak: bestStreak
+          })
+          .then(() => {
+            renderSetupRecords();
+          })
+          .catch(error => console.error("Error saving record:", error))
+          .then(() => fadeOutToMenu(quitToSettings));
+        } else {
+          fadeOutToMenu(quitToSettings);
+        }
+      });
     }
   }, 1000);
 }
@@ -2748,29 +2749,30 @@ function checkFinalStartButtonState() {
             playFromStart(soundElectricShock);
             endButton.classList.add('electric-effect');
             setTimeout(() => endButton.classList.remove('electric-effect'), 1000);
-            const name = prompt('¿Cómo te llamas?'); // La variable name debe ser local a este scope
-            if (name) {
-                const recordData = {
-                    name: name,
-                    score: score,
-                    mode: selectedGameMode, // Asegúrate que selectedGameMode esté disponible (global o en este ámbito)
-                    timestamp: firebase.firestore.FieldValue.serverTimestamp(),
-                    tense: currentOptions.tenses, // currentOptions debe estar disponible
-                    verb: currentQuestion.verb.infinitive_es, // currentQuestion debe estar disponible
-                    streak: bestStreak 
-                };
-                db.collection("records").add(recordData)
-                  .then(() => {
-                    renderSetupRecords();
-                    updateRanking();
-                  })
-                  .catch(error => {
-                    console.error("Error saving record (endButton):", error);
-                  })
-                  .then(() => fadeOutToMenu(quitToSettings));
-            } else {
-                fadeOutToMenu(quitToSettings);
-            }
+            openNameModal('¿Cómo te llamas?', function(name) {
+                if (name) {
+                    const recordData = {
+                        name: name,
+                        score: score,
+                        mode: selectedGameMode,
+                        timestamp: firebase.firestore.FieldValue.serverTimestamp(),
+                        tense: currentOptions.tenses,
+                        verb: currentQuestion.verb.infinitive_es,
+                        streak: bestStreak
+                    };
+                    db.collection("records").add(recordData)
+                      .then(() => {
+                        renderSetupRecords();
+                        updateRanking();
+                      })
+                      .catch(error => {
+                        console.error("Error saving record (endButton):", error);
+                      })
+                      .then(() => fadeOutToMenu(quitToSettings));
+                } else {
+                    fadeOutToMenu(quitToSettings);
+                }
+            });
         });
     }
 
@@ -2890,6 +2892,54 @@ if (closeSpecificModalBtn) {
 }
 if (specificModalBackdrop) {
   specificModalBackdrop.addEventListener('click', closeSpecificModal);
+}
+
+// ----- Name Entry Modal -----
+const nameModal = document.getElementById('name-entry-modal');
+const nameModalBackdrop = document.getElementById('name-modal-backdrop');
+const nameModalMessage = document.getElementById('name-entry-message');
+const playerNameInput = document.getElementById('player-name-input');
+const nameSubmitButton = document.getElementById('name-submit-button');
+const closeNameModalBtn = document.getElementById('close-name-modal-btn');
+
+function openNameModal(message, callback) {
+  if (!nameModal || !nameModalBackdrop) return;
+  nameModalMessage.textContent = message;
+  nameModal.style.display = 'flex';
+  nameModalBackdrop.style.display = 'block';
+  document.body.classList.add('tooltip-open-no-scroll');
+  if (playerNameInput) {
+    playerNameInput.value = '';
+    playerNameInput.focus();
+  }
+
+  function cleanup() {
+    nameModal.style.display = 'none';
+    nameModalBackdrop.style.display = 'none';
+    document.body.classList.remove('tooltip-open-no-scroll');
+    nameSubmitButton.removeEventListener('click', submitHandler);
+    playerNameInput.removeEventListener('keydown', keyHandler);
+    if (closeNameModalBtn) closeNameModalBtn.removeEventListener('click', cancelHandler);
+    nameModalBackdrop.removeEventListener('click', cancelHandler);
+  }
+
+  function submitHandler() {
+    const val = playerNameInput ? playerNameInput.value.trim() : '';
+    cleanup();
+    callback(val);
+  }
+
+  function cancelHandler() {
+    cleanup();
+    callback(null);
+  }
+
+  function keyHandler(e) { if (e.key === 'Enter') submitHandler(); }
+
+  nameSubmitButton.addEventListener('click', submitHandler);
+  playerNameInput.addEventListener('keydown', keyHandler);
+  if (closeNameModalBtn) closeNameModalBtn.addEventListener('click', cancelHandler);
+  nameModalBackdrop.addEventListener('click', cancelHandler);
 }
 
 function updateGameTitle() {

--- a/style.css
+++ b/style.css
@@ -2766,6 +2766,31 @@ body,
   color: var(--accent-color-red);
 }
 
+/* Modal for entering player's name */
+#name-entry-modal input[type="text"] {
+  font-family: var(--font-pixel);
+  font-size: 1.2em;
+  background-color: var(--input-bg);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  padding: 8px 10px;
+  width: calc(100% - 22px);
+  margin-bottom: 15px;
+  border-radius: 0;
+}
+
+#name-entry-modal button.name-submit {
+  font-family: var(--font-pixel);
+  padding: 10px 20px;
+  background-color: var(--accent-color-blue);
+  color: var(--bg-color);
+  border: 1px solid var(--border-color);
+  cursor: pointer;
+}
+#name-entry-modal button.name-submit:hover {
+  background-color: var(--accent-color-red);
+}
+
 .context-info-icon {
   position: absolute;
   top: 5px;


### PR DESCRIPTION
## Summary
- add a modal in index.html for entering the player's name
- style the name-entry modal in style.css
- implement `openNameModal` in script.js and use it instead of prompts

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684666db4854832796dbbac604824f13