### PR TITLE
Fix modal visibility on initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,14 +22,14 @@
 <script src="https://www.google.com/recaptcha/enterprise.js?render=6LfwDVErAAAAAJSaqfJCAJXQBO9Ivm7zH6NC8bJZ"></script>
 </head>
 <body class="is-loading">
-  <div id="specific-modal-backdrop" class="specific-modal-backdrop"></div>
-  <div id="specific-info-modal" class="specific-modal">
+  <div id="specific-modal-backdrop" class="specific-modal-backdrop" style="display:none;"></div>
+  <div id="specific-info-modal" class="specific-modal" style="display:none;">
     <div class="specific-modal-content">
     </div>
     <button id="close-specific-modal-btn" class="specific-modal-close-btn">&times;</button>
   </div>
-  <div id="name-modal-backdrop" class="specific-modal-backdrop"></div>
-  <div id="name-entry-modal" class="specific-modal">
+  <div id="name-modal-backdrop" class="specific-modal-backdrop" style="display:none;"></div>
+  <div id="name-entry-modal" class="specific-modal" style="display:none;">
     <div class="specific-modal-content">
       <h2 id="name-modal-title">🏆 New Record! 🏆</h2>
       <p id="name-entry-message">Enter your name:</p>


### PR DESCRIPTION
## Summary
- hide specific info modal and name entry modal by default so they only appear when triggered by the script

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684677f55e408327ba800ce1d2fcccad