### PR TITLE
Update skip bubble color

### DIFF
--- a/script.js
+++ b/script.js
@@ -68,7 +68,7 @@ function chuacheSpeaks(type) {
   image.src = "images/chuachetalks.gif";
   bubble.textContent = message;
   bubble.classList.remove("hidden");
-  if (type === "wrong") bubble.classList.add("error");
+  if (type === "wrong" || type === "skip") bubble.classList.add("error");
   else bubble.classList.remove("error");
 
   playFromStart(chuacheSound);


### PR DESCRIPTION
## Summary
- make skip messages from Chuache display in red to match clue hints

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68467e22a964832784e622298f3e3c4e