### PR TITLE
Restructures game layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,10 +201,10 @@
   </div>
 
   <div id="game-screen" class="screen" style="display: none;">
+    <h2 id="game-title"></h2>
     <div id="game-layout">
       <div id="game-main">
         <canvas id="life-confetti-canvas"></canvas>
-        <h2 id="game-title"></h2>
 
 	  <div id="lives-mechanics-display" style="display: none; text-align: center; margin-bottom: 15px;">
 		<span id="total-correct-for-life-display" style="margin-right: 20px;"></span>
@@ -246,14 +246,6 @@
           <button id="end-button">END GAME</button>
         </div>
         <div id="feedback-area"></div>
-
-      <div id="score-container">
-         <div id="score-display"></div>
-		 <div id="streak-display"></div>
-		 <div id="flames"></div>
-      </div>
-
-      <div id="ranking-box"></div>
       </div>
       <div id="chuache-box">
         <div id="chuache-container">
@@ -261,6 +253,14 @@
           <img id="chuache-image" src="images/conjuchuache.webp" alt="Chuache">
         </div>
       </div>
+    </div>
+    <div id="score-section">
+      <div id="score-container">
+         <div id="score-display"></div>
+         <div id="streak-display"></div>
+         <div id="flames"></div>
+      </div>
+      <div id="ranking-box"></div>
     </div>
   </div>
   <div id="left-bubbles"></div>

--- a/style.css
+++ b/style.css
@@ -821,6 +821,11 @@ button:active {
   text-align: center;      /* centra títulos, botones inline, etc. */
 }
 
+#score-section {
+  text-align: center;
+  margin-top: 20px;
+}
+
 #question-prompt,
 #feedback-area,
 #score-container,
@@ -3197,11 +3202,11 @@ td.irregular-highlight {
 }
 
 #game-main {
-  flex: 1;
+  flex: 0 0 70%;
 }
 
 #chuache-box {
-  width: 170px;
+  flex: 0 0 30%;
   position: relative;
 }
 
@@ -3221,6 +3226,7 @@ td.irregular-highlight {
 
 @media (max-width: 600px) {
   #chuache-box {
+    flex-basis: 30%;
     width: 120px;
   }
   #chuache-container {


### PR DESCRIPTION
## Summary
- reorganize layout of game area
- place mode/tense section above game columns
- move score and ranking info to a dedicated block
- adjust CSS for 70/30 column split and new score section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684686511b3083278c2a07154a7d0c43