### PR TITLE
Update layout to show Chuache on left

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,15 +203,21 @@
   <div id="game-screen" class="screen" style="display: none;">
     <h2 id="game-title"></h2>
     <div id="game-layout">
-
+      <div id="chuache-box">
+        <div id="chuache-container">
+          <div id="speech-bubble" class="speech-bubble hidden">You just got lucky.</div>
+          <img id="chuache-image" src="images/conjuchuache.webp" alt="Chuache">
+        </div>
+      </div>
 
       <div id="game-main">
         <canvas id="life-confetti-canvas"></canvas>
 
-	  <div id="lives-mechanics-display" style="display: none; text-align: center; margin-bottom: 15px;">
-		<span id="total-correct-for-life-display" style="margin-right: 20px;"></span>
-		<span id="streak-for-life-display"></span>
-	  </div>
+          <div id="lives-mechanics-display" style="display: none; text-align: center; margin-bottom: 15px;">
+                <span id="total-correct-for-life-display" style="margin-right: 20px;"></span>
+                <span id="streak-for-life-display"></span>
+                <span id="lives-count-wrapper"></span>
+          </div>
 	  
     <div id="timer-container" class="timer-container" style="display:none;">
       <div id="timer-clock" class="timer-item">⏳ 4:00</div>
@@ -243,13 +249,6 @@
         </div>		   
       </div>
 	  
-        </div>
-        <div id="chuache-box">
-          <div id="chuache-container">
-            <div id="speech-bubble" class="speech-bubble hidden">You just got lucky.</div>
-            <img id="chuache-image" src="images/conjuchuache.webp" alt="Chuache">
-          </div>
-        </div>
         </div>
       </div>
       <div id="action-buttons">

--- a/script.js
+++ b/script.js
@@ -3050,11 +3050,16 @@ function updateGameTitle() {
     </div>
   `;
 
-  if (selectedGameMode === 'lives') {
-    html += `<div class="lives-display"><span id="lives-count">${remainingLives}</span><img src="images/heart.webp" alt="life" style="width:40px; height:40px; vertical-align: middle; margin-left: 6px;"></div>`;
-  }
-
   gameTitle.innerHTML = html;
+
+  const livesWrapper = document.getElementById('lives-count-wrapper');
+  if (livesWrapper) {
+    if (selectedGameMode === 'lives') {
+      livesWrapper.innerHTML = `<span id="lives-count">${remainingLives}</span><img src="images/heart.webp" alt="life" style="width:40px; height:40px; vertical-align: middle; margin-left: 6px;">`;
+    } else {
+      livesWrapper.innerHTML = '';
+    }
+  }
 
   const modeBadgeEl = gameTitle.querySelector('.mode-badge');
   if (modeBadgeEl && modeBadgeEl.dataset.infoKey) {

--- a/style.css
+++ b/style.css
@@ -482,9 +482,10 @@ button:active {
 }
 
 #answer-area label {
-  display: block; /* Cada label en su línea */
-  margin-bottom: 5px;
+  display: inline-block;
+  margin-right: 10px;
   font-size: 1.1em;
+  margin-bottom: 0;
 }
 
 #answer-area input[type="text"] {
@@ -494,7 +495,7 @@ button:active {
   color: var(--text-color);
   border: 1px solid var(--border-color);
   padding: 8px 10px;
-  width: calc(100% - 22px); /* Ajustar ancho con padding/border */
+  width: auto;
   margin-bottom: 15px;
   border-radius: 0;
 }
@@ -545,9 +546,13 @@ button:active {
 /* Área de Puntuación */
 #score-display {
   margin-top: 20px;
-  font-size: 2.1em;
+  font-size: 1.2em;
   background-color: transparent;
   padding: 10px;
+}
+
+#streak-display {
+  font-size: 1em;
 }
 
 
@@ -841,6 +846,10 @@ button:active {
 #input-en-container {
   width: 80%;
   margin: 0 auto 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
 }
 
 #answer-area button,
@@ -850,8 +859,8 @@ button:active {
 }
 
 #answer-area {
-  flex: 0 0 70%;
-  max-width: 70%;
+  flex: 0 0 100%;
+  max-width: 100%;
 }
 
 #action-buttons {
@@ -3205,17 +3214,18 @@ td.irregular-highlight {
 
 #game-layout {
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 }
 
 #game-main {
-  flex: 1 1 auto;
+  flex: 0 0 70%;
+  max-width: 70%;
 }
 
 #answer-row {
   display: flex;
-  align-items: flex-start;
+  justify-content: center;
+  width: 100%;
 }
 
 #chuache-box {
@@ -3252,7 +3262,6 @@ td.irregular-highlight {
     flex-basis: 100%;
     max-width: 100%;
   }
-}
 }
 
 .speech-bubble {


### PR DESCRIPTION
## Summary
- restructure game layout so antagonist section sits left of main game board
- move lives counter next to streak information
- shrink score bar text
- adjust input rows to display labels and fields inline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846deacbae08327b165ac748eae7b7c