### PR TITLE
Add Study Mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,10 @@
             5x💖
             <span class="context-info-icon" data-info-key="livesMode"></span>
           </button>
+          <button class="mode-button config-flow-button" data-mode="study" data-infokey="studyMode">
+            📚 Study Mode
+            <span class="context-info-icon" data-info-key="studyMode"></span>
+          </button>
         </div>
         <button id="confirm-mode-button" class="confirm-button" style="display: none;">Confirm Mode</button>
       </div>

--- a/script.js
+++ b/script.js
@@ -2002,6 +2002,7 @@ function prepareNextQuestion() {
 }
 
 function checkAnswer() {
+  const isStudyMode = (selectedGameMode === 'study');
   let possibleCorrectAnswers = [];
   const rt    = (Date.now() - startTime) / 1000;
   const bonus = Math.max(1, 2 - Math.max(0, rt - 5) * 0.1); 
@@ -2164,12 +2165,18 @@ function checkAnswer() {
 }
 
   if (correct) {
+    if (isStudyMode) {
+      soundCorrect.play();
+      feedback.innerHTML = `✅ Correct!`;
+      setTimeout(prepareNextQuestion, 200);
+      return;
+    }
     // Manejo del sonido
     if (soundCorrect) {
       soundCorrect.pause();
       soundCorrect.currentTime = 0;
       soundCorrect.play().catch(()=>{/* ignora errores por autoplay */});
-    } // CIERRE DEL if (soundCorrect)
+    }
     chuacheSpeaks('correct');
 	
     // El resto de la lógica para una respuesta correcta DEBE ESTAR AQUÍ DENTRO
@@ -2297,6 +2304,12 @@ function checkAnswer() {
 	
     return;   
   } else {
+    if (isStudyMode) {
+      soundWrong.play();
+      feedback.innerHTML = `❌ Incorrect. The correct answer was <strong>"${currentQuestion.answer}"</strong>.`;
+      setTimeout(prepareNextQuestion, 1500);
+      return;
+    }
     soundWrong.play();
     chuacheSpeaks('wrong');
     streak = 0;
@@ -2629,6 +2642,7 @@ function updateStreakForLifeDisplay() {
 
 function quitToSettings() {
   document.getElementById('timer-container').style.display = 'none';
+  document.getElementById('game-screen').classList.remove('study-mode-active');
   clearInterval(countdownTimer);
   stopBubbles();
   gameMusic.pause();
@@ -2750,6 +2764,10 @@ finalStartGameButton.addEventListener('click', async () => {
     // Ocultar pantalla de configuración de flujo y mostrar pantalla de juego
     configFlowScreen.style.display = 'none';
     gameScreen.style.display = 'block';
+    gameScreen.classList.remove('study-mode-active');
+    if (selectedGameMode === 'study') {
+        gameScreen.classList.add('study-mode-active');
+    }
     ensureChuachePosition();
     animateChuacheToGame();
     if (window.innerWidth > 1200) startBubbles();

--- a/style.css
+++ b/style.css
@@ -13,6 +13,34 @@
   font-style: normal;
 }
 
+/* ==========================================================================
+   ====== STYLES FOR MINIMALIST STUDY MODE ======
+   ========================================================================== */
+
+/* When the game screen has the 'study-mode-active' class... */
+
+/* 1. Hide all non-essential UI elements */
+.study-mode-active #chuache-box,
+.study-mode-active #score-section,
+.study-mode-active #game-mechanics-bar,
+.study-mode-active #interaction-panel {
+  display: none !important;
+}
+
+/* 2. Re-center the main game layout */
+.study-mode-active #game-layout {
+  display: block;
+  width: 100%;
+}
+
+/* 3. Make the main content area centered and appropriately sized */
+.study-mode-active #game-main {
+  flex-basis: 100%;
+  max-width: 700px;
+  margin: 0 auto;
+  padding-right: 0;
+}
+
 :root {
   --bg-color: #1a2a1a;
   --container-bg: #2a3a2a;

--- a/tooltips.js
+++ b/tooltips.js
@@ -32,7 +32,19 @@ const specificInfoData = {
               - Appear randomly in "<span class="difficulty-normal">Conjugate</span>" (⚙️) and "<span class="difficulty-hard">Produce</span>" (⌨️) difficulties if the verb is irregular or reflexive.<br>
               - Chance: Approx. <span class="emphasis-mechanic">1 in 30</span> for "Conjugate", approx. <span class="emphasis-mechanic">1 in 20</span> for "Produce".<br>
               - Correctly conjugating a prize verb (marked with 🎁) grants an <span class="emphasis-mechanic">extra life!</span><br>
-           <br><strong class="modal-subtitle">Goal:</strong> Stay alive and get the highest score!`
+          <br><strong class="modal-subtitle">Goal:</strong> Stay alive and get the highest score!`
+  },
+  studyMode: {
+    title: "📚 Study Mode",
+    html: `<p>A minimalist mode for focused practice without distractions.</p>
+         <strong class="modal-subtitle">Features:</strong>
+         <ul>
+           <li>No points, no score, no streaks.</li>
+           <li>No timer or lives.</li>
+           <li>No character or character sounds.</li>
+           <li>The feedback area is used only for providing clues or showing the correct answer.</li>
+         </ul>
+         <p><strong>Goal:</strong> Practice conjugations at your own pace.</p>`
   },
   receptiveConfig: {
     title: "💭 Recall Mode",


### PR DESCRIPTION
## Summary
- add Study Mode button
- include Study Mode tooltip description
- hide UI elements and recenter layout when Study Mode active
- toggle study-mode-active class when starting/leaving game
- simplify feedback and scoring in Study Mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68481ed113f0832785b2c19de0334c34