### PR TITLE
Disable Top 5 message in study mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -1744,9 +1744,14 @@ function applyIrregularityAndTenseFiltersToVerbList() {
     updateGroupButtons();
 }
   function updateRanking() {
-    rankingBox.innerHTML = '<h3>🏆 Top 5</h3>';
     const mode = selectedGameMode || window.selectedGameMode;
     if (!mode) return;
+    if (mode === 'study') {
+      rankingBox.innerHTML = '';
+      return;
+    }
+
+    rankingBox.innerHTML = '<h3>🏆 Top 5</h3>';
 
     db.collection("records")
       .where("mode", "==", mode)


### PR DESCRIPTION
## Summary
- update `updateRanking` to hide Top 5 ranking when study mode is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848224c09688327839349376161c800