### PR TITLE
Fix Study Mode confirm button color

### DIFF
--- a/style.css
+++ b/style.css
@@ -3109,11 +3109,6 @@ body.is-loading .modal-backdrop:not(.specific-modal-backdrop) { /* :not para no 
     /* pointer-events: none;  // Considera quitar esto si quieres que sea clickeable para volver */
     display: block !important; /* Asegurar que sea visible */
 }
-.config-flow-button[data-infokey="studyMode"].confirmed-selection {
-    background-color: #ffffff !important; /* Blanco */
-    color: #000000 !important; /* Texto negro */
-    border: 2px solid #000000 !important;
-}
 .config-step.step-section-completed .config-flow-button:not(.confirmed-selection) {
     display: none !important; /* Oculta los otros botones */
 }


### PR DESCRIPTION
## Summary
- remove custom white coloring for Study Mode when confirmed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848272524d48327997e9e633b867055