### PR TITLE
Integrate study mode sound and mute music

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ let typeInterval; // Variable global para controlar el intervalo de la animació
 
 const soundCorrect = new Audio('sounds/correct.mp3');
 const soundWrong = new Audio('sounds/wrong.mp3');
+const soundWrongStudy = new Audio('sounds/wongstudy.mp3');
 const soundClick = new Audio('sounds/click.mp3');
 const soundStart = new Audio('sounds/start-verb.mp3');
 const soundSkip = new Audio('sounds/skip.mp3');
@@ -2311,7 +2312,11 @@ function checkAnswer() {
 	
     return;   
   } else {
-    soundWrong.play();
+    if (isStudyMode) {
+      soundWrongStudy.play();
+    } else {
+      soundWrong.play();
+    }
     chuacheSpeaks('wrong');
     streak = 0;
     multiplier = 1.0;
@@ -2808,9 +2813,15 @@ finalStartGameButton.addEventListener('click', async () => {
             if (currentMusic !== gameMusic) {
                 currentMusic = gameMusic;
             }
-            if (gameMusic.paused && musicPlaying) {
+            if (selectedGameMode !== 'study' && gameMusic.paused && musicPlaying) {
                 gameMusic.volume = targetVolume;
                 gameMusic.play();
+            } else {
+                gameMusic.pause();
+                if (musicIcon) {
+                    musicIcon.src = 'images/musicoff.webp';
+                    musicIcon.alt = 'Music off';
+                }
             }
             musicToggle.style.display = 'block';
             volumeSlider.style.display = 'block';

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'conjugator-cache-v1';
+const CACHE_NAME = 'conjugator-cache-v2';
 const URLS_TO_CACHE = [
   'index.html',
   'style.css',
@@ -16,6 +16,7 @@ const URLS_TO_CACHE = [
   'sounds/click.mp3',
   'sounds/correct.mp3',
   'sounds/wrong.mp3',
+  'sounds/wongstudy.mp3',
   'sounds/gameover.mp3',
   'sounds/musicmenu.mp3',
   'sounds/musicgame.mp3',


### PR DESCRIPTION
## Summary
- add dedicated wrong-answer sound for study mode
- disable background music by default when starting study mode
- cache new sound via service worker

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848284a443083279cc36d5fabfe8686