### PR TITLE
Extiende duración de mensajes de Chuache

### DIFF
--- a/script.js
+++ b/script.js
@@ -93,7 +93,7 @@ function chuacheSpeaks(type) {
     image.src = "images/conjuchuache.webp";
     bubble.classList.add("hidden");
     bubble.classList.remove("error");
-  }, 2000);
+  }, 3000);
 }
 
 function playFromStart(audio) {


### PR DESCRIPTION
## Summary
- ajusta `chuacheSpeaks` para mantener el globo de diálogo activo durante 3s

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848381a12d48327860ed4537a7fde8a