### PR TITLE
Implement placeholder goal text

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,17 +225,14 @@
             <div id="question-area">
               <div id="tense-label" class="tense-label"></div>
               <div id="question-prompt">Loading…</div>
-              <p>Your goal:</p>
             </div>
 
             <div id="answer-row">
             <div id="answer-area">
               <div id="input-es-container">
-                <label for="answer-input-es">Conjugate in Spanish:</label>
-                <input type="text" id="answer-input-es">
+                <input type="text" id="answer-input-es" placeholder="Conjugate in Spanish" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false">
               </div>
               <div id="input-en-container" style="display:none;">
-                <label for="answer-input-en">Conjugate in English:</label>
                 <input type="text" id="answer-input-en" placeholder="e.g. You all ate" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false">
                 <div id="pronoun-hints" style="margin-top:8px;">
                   <span class="pronoun-button">I</span>

--- a/style.css
+++ b/style.css
@@ -3437,6 +3437,12 @@ td.irregular-highlight {
   width: auto;
 }
 
+#answer-input-es::placeholder,
+#answer-input-en::placeholder {
+  color: #999999;
+  opacity: 1;
+}
+
 /* Estilo destacado para la puntuación */
 #score-container #score-display {
   /* Tamaño de fuente mayor para destacar la puntuación */


### PR DESCRIPTION
## Summary
- simplify instructions by removing `Your goal:` text
- move goal text into the input boxes as placeholders
- style placeholders for both input fields

## Testing
- `grep -n "Your goal" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_6848d3558b9c8327b0c8721e0d97f568