### PR TITLE
Update clue logic for conjugate mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -218,7 +218,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   let tickingSoundPlaying = false;
 
   function updateClueButton() {
-    const maxClues = currentOptions.mode === 'receptive' ? 1 : 2;
+    const maxClues =
+      currentOptions.mode === 'receptive' ||
+      currentOptions.mode === 'productive_easy'
+        ? 1
+        : 2;
     if (!checkButton) return;
     if (currentQuestion.hintLevel >= maxClues) {
       checkButton.innerHTML = `<span class="no-clues-left">Get Clue ${maxClues}/${maxClues}</span> / Check Answer`;
@@ -2393,28 +2397,41 @@ function checkAnswer() {
 		ansEN.value = '';
 		setTimeout(() => ansEN.focus(), 0);
 		return;
-	} else if (currentOptions.mode === 'productive' || currentOptions.mode === 'productive_easy') {
-		// Existing hint logic for productive modes (should be in English already based on your original code)
-		if (currentQuestion.hintLevel === 0) {
-                        // Provide Clue 1 with proper spacing
-                        feedback.innerHTML =
-                          `❌ <em>Clue 1:</em> infinitive is <strong>${currentQuestion.verb.infinitive_es}</strong>.`; // This refers to Spanish infinitive, which is contextually correct for this mode
-                        playFromStart(soundElectricShock);
-                        currentQuestion.hintLevel = 1;
-                        updateClueButton();
-                } else if (currentQuestion.hintLevel === 1) {
-			// Ensure tenseKey is used if currentOptions.tenses can be an array
-			const conjTenseKey = currentQuestion.tenseKey;
-			const conj = currentQuestion.verb.conjugations[conjTenseKey];
-			const botones = Object.entries(conj || {}) // Add guard for conj
-				.filter(([pr]) => pr !== currentQuestion.pronoun)
-				.map(([, form]) => `<span class="hint-btn">${form}</span>`)
-				.join('');
-                        feedback.innerHTML =
-                                `❌ <em>Clue 2:</em> ` + botones;
-                        playFromStart(soundElectricShock);
-                        currentQuestion.hintLevel = 2;
-                        updateClueButton();
+        } else if (currentOptions.mode === 'productive' || currentOptions.mode === 'productive_easy') {
+                if (currentOptions.mode === 'productive_easy') {
+                        if (currentQuestion.hintLevel === 0) {
+                                const conjTenseKey = currentQuestion.tenseKey;
+                                const conj = currentQuestion.verb.conjugations[conjTenseKey];
+                                const botones = Object.entries(conj || {})
+                                        .filter(([pr]) => pr !== currentQuestion.pronoun)
+                                        .map(([, form]) => `<span class="hint-btn">${form}</span>`)
+                                        .join('');
+                                feedback.innerHTML =
+                                        `❌ <em>Clue 1:</em> ` + botones;
+                                playFromStart(soundElectricShock);
+                                currentQuestion.hintLevel = 1;
+                                updateClueButton();
+                        }
+                } else { // productive mode keeps two clues
+                        if (currentQuestion.hintLevel === 0) {
+                                feedback.innerHTML =
+                                  `❌ <em>Clue 1:</em> infinitive is <strong>${currentQuestion.verb.infinitive_es}</strong>.`;
+                                playFromStart(soundElectricShock);
+                                currentQuestion.hintLevel = 1;
+                                updateClueButton();
+                        } else if (currentQuestion.hintLevel === 1) {
+                                const conjTenseKey = currentQuestion.tenseKey;
+                                const conj = currentQuestion.verb.conjugations[conjTenseKey];
+                                const botones = Object.entries(conj || {})
+                                        .filter(([pr]) => pr !== currentQuestion.pronoun)
+                                        .map(([, form]) => `<span class="hint-btn">${form}</span>`)
+                                        .join('');
+                                feedback.innerHTML =
+                                        `❌ <em>Clue 2:</em> ` + botones;
+                                playFromStart(soundElectricShock);
+                                currentQuestion.hintLevel = 2;
+                                updateClueButton();
+                        }
                 }
 		ansES.value = '';
 		setTimeout(() => ansES.focus(), 0);


### PR DESCRIPTION
## Summary
- reduce available clues in conjugate mode to one
- reuse former second clue as the only clue in that mode
- keep two clues in productive mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854bbbbe78c8327ad6c9f3e282450f1