### PR TITLE
Add vos pronoun support

### DIFF
--- a/script.js
+++ b/script.js
@@ -582,12 +582,13 @@ backButton.addEventListener('click', () => {
     }
  
 
-  const pronouns = ['yo','tú','él','nosotros','vosotros','ellos'];
+  const pronouns = ['yo','tú','vos','él','nosotros','vosotros','ellos'];
   const pronounMap = {
     yo: ['I'],
     tú: ['you'],
     él: ['he', 'she'],
-	usted: ['he', 'she'],
+        usted: ['he', 'she'],
+    vos: ['you'],
     nosotros: ['we'],
     vosotros: ['you'],
     ellos: ['they'],
@@ -610,6 +611,7 @@ window.addEventListener("load", () => {
 const pronounGroups = [
   { label: 'yo',                   values: ['yo'] },
   { label: 'tú',                   values: ['tú'] },
+  { label: 'vos',                  values: ['vos'] },
   { label: 'él / ella / usted',    values: ['él'] },
   { label: 'nosotros / nosotras',  values: ['nosotros'] },
   { label: 'vosotros / vosotras',  values: ['vosotros'] },
@@ -1332,7 +1334,9 @@ function renderVerbButtons() {
 		btn.classList.add('pronoun-group-button');
 		btn.dataset.values    = JSON.stringify(group.values);
 		btn.textContent       = group.label;
-		btn.classList.add('selected');  // todos activos por defecto
+                if (group.label !== 'vos') {
+                    btn.classList.add('selected');  // todos activos por defecto
+                }
 		container.appendChild(btn);
 	  });
 	}
@@ -1892,7 +1896,7 @@ function prepareNextQuestion() {
    // Paso 2: construye pronList con fallback a la lista global
    const pronList = allowedPronouns.length > 0
      ? allowedPronouns
-     : pronouns;   // ['yo','tú','él','nosotros','vosotros','ellos']
+    : pronouns;   // ['yo','tú','vos','él','nosotros','vosotros','ellos']
  
    // Paso 3: elige el pronombre interno de pronList
    const originalPronoun = pronList[
@@ -2710,7 +2714,7 @@ function quitToSettings() {
     initTenseDropdown(); // Reinicializar listeners de dropdown si es necesario
     renderVerbButtons(); // Debería seleccionar los regulares no reflexivos por defecto
     initVerbDropdown();
-    renderPronounButtons(); // Debería seleccionar todos por defecto
+    renderPronounButtons(); // "vos" desactivado por defecto
     initPronounDropdown();
     renderVerbTypeButtons(); // Debería seleccionar "regular" por defecto
     filterVerbTypes(); // Aplicar filtros basados en los tiempos por defecto
@@ -3441,7 +3445,8 @@ function createBubble(side) {
 
   const availableTenseValues = tenses.map(t => t.value);
   const tense = availableTenseValues[Math.floor(Math.random() * availableTenseValues.length)];
-  const pronoun = Object.keys(verb.conjugations[tense] || {})[Math.floor(Math.random() * 6)];
+  const pronounKeys = Object.keys(verb.conjugations[tense] || {});
+  const pronoun = pronounKeys[Math.floor(Math.random() * pronounKeys.length)];
   const conjugation = verb.conjugations[tense]?.[pronoun];
 
   bubble.textContent = conjugation || verb.infinitive_es;

--- a/verbos.json
+++ b/verbos.json
@@ -11,12 +11,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "como", "tú": "comes", "él": "come", "nosotros": "comemos", "vosotros": "coméis", "ellos": "comen"},
-      "past_simple": {"yo": "comí", "tú": "comiste", "él": "comió", "nosotros": "comimos", "vosotros": "comisteis", "ellos": "comieron"},
-      "present_perfect": {"yo": "he comido", "tú": "has comido", "él": "ha comido", "nosotros": "hemos comido", "vosotros": "habéis comido", "ellos": "han comido"},
-      "future_simple": {"yo": "comeré", "tú": "comerás", "él": "comerá", "nosotros": "comeremos", "vosotros": "comeréis", "ellos": "comerán"},
-      "condicional_simple": {"yo": "comería", "tú": "comerías", "él": "comería", "nosotros": "comeríamos", "vosotros": "comeríais", "ellos": "comerían"},
-      "imperfect_indicative": {"yo": "comía", "tú": "comías", "él": "comía", "nosotros": "comíamos", "vosotros": "comíais", "ellos": "comían"}
+      "present": {"yo": "como", "tú": "comes", "vos": "comés", "él": "come", "nosotros": "comemos", "vosotros": "coméis", "ellos": "comen"},
+      "past_simple": {"yo": "comí", "tú": "comiste", "vos": "comiste", "él": "comió", "nosotros": "comimos", "vosotros": "comisteis", "ellos": "comieron"},
+      "present_perfect": {"yo": "he comido", "tú": "has comido", "vos": "has comido", "él": "ha comido", "nosotros": "hemos comido", "vosotros": "habéis comido", "ellos": "han comido"},
+      "future_simple": {"yo": "comeré", "tú": "comerás", "vos": "comerás", "él": "comerá", "nosotros": "comeremos", "vosotros": "comeréis", "ellos": "comerán"},
+      "condicional_simple": {"yo": "comería", "tú": "comerías", "vos": "comerías", "él": "comería", "nosotros": "comeríamos", "vosotros": "comeríais", "ellos": "comerían"},
+      "imperfect_indicative": {"yo": "comía", "tú": "comías", "vos": "comías", "él": "comía", "nosotros": "comíamos", "vosotros": "comíais", "ellos": "comían"}
     },
     "conjugations_en": {
       "present": {"I": "eat", "you": "eat", "he": "eats", "she": "eats", "it": "eats", "we": "eat", "they": "eat"},
@@ -39,12 +39,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "hablo", "tú": "hablas", "él": "habla", "nosotros": "hablamos", "vosotros": "habláis", "ellos": "hablan"},
-      "past_simple": {"yo": "hablé", "tú": "hablaste", "él": "habló", "nosotros": "hablamos", "vosotros": "hablasteis", "ellos": "hablaron"},
-      "present_perfect": {"yo": "he hablado", "tú": "has hablado", "él": "ha hablado", "nosotros": "hemos hablado", "vosotros": "habéis hablado", "ellos": "han hablado"},
-      "future_simple": {"yo": "hablaré", "tú": "hablarás", "él": "hablará", "nosotros": "hablaremos", "vosotros": "hablaréis", "ellos": "hablarán"},
-      "condicional_simple": {"yo": "hablaría", "tú": "hablarías", "él": "hablaría", "nosotros": "hablaríamos", "vosotros": "hablaríais", "ellos": "hablarían"},
-      "imperfect_indicative": {"yo": "hablaba", "tú": "hablabas", "él": "hablaba", "nosotros": "hablábamos", "vosotros": "hablabais", "ellos": "hablaban"}
+      "present": {"yo": "hablo", "tú": "hablas", "vos": "hablás", "él": "habla", "nosotros": "hablamos", "vosotros": "habláis", "ellos": "hablan"},
+      "past_simple": {"yo": "hablé", "tú": "hablaste", "vos": "hablaste", "él": "habló", "nosotros": "hablamos", "vosotros": "hablasteis", "ellos": "hablaron"},
+      "present_perfect": {"yo": "he hablado", "tú": "has hablado", "vos": "has hablado", "él": "ha hablado", "nosotros": "hemos hablado", "vosotros": "habéis hablado", "ellos": "han hablado"},
+      "future_simple": {"yo": "hablaré", "tú": "hablarás", "vos": "hablarás", "él": "hablará", "nosotros": "hablaremos", "vosotros": "hablaréis", "ellos": "hablarán"},
+      "condicional_simple": {"yo": "hablaría", "tú": "hablarías", "vos": "hablarías", "él": "hablaría", "nosotros": "hablaríamos", "vosotros": "hablaríais", "ellos": "hablarían"},
+      "imperfect_indicative": {"yo": "hablaba", "tú": "hablabas", "vos": "hablabas", "él": "hablaba", "nosotros": "hablábamos", "vosotros": "hablabais", "ellos": "hablaban"}
     },
     "conjugations_en": {
       "present": {"I": "talk", "you": "talk", "he": "talks", "she": "talks", "it": "talks", "we": "talk", "they": "talk"},
@@ -67,12 +67,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "vivo", "tú": "vives", "él": "vive", "nosotros": "vivimos", "vosotros": "vivís", "ellos": "viven"},
-      "past_simple": {"yo": "viví", "tú": "viviste", "él": "vivió", "nosotros": "vivimos", "vosotros": "vivisteis", "ellos": "vivieron"},
-      "present_perfect": {"yo": "he vivido", "tú": "has vivido", "él": "ha vivido", "nosotros": "hemos vivido", "vosotros": "habéis vivido", "ellos": "han vivido"},
-      "future_simple": {"yo": "viviré", "tú": "vivirás", "él": "vivirá", "nosotros": "viviremos", "vosotros": "viviréis", "ellos": "vivirán"},
-      "condicional_simple": {"yo": "viviría", "tú": "vivirías", "él": "viviría", "nosotros": "viviríamos", "vosotros": "viviríais", "ellos": "vivirían"},
-      "imperfect_indicative": {"yo": "vivía", "tú": "vivías", "él": "vivía", "nosotros": "vivíamos", "vosotros": "vivíais", "ellos": "vivían"}
+      "present": {"yo": "vivo", "tú": "vives", "vos": "vivís", "él": "vive", "nosotros": "vivimos", "vosotros": "vivís", "ellos": "viven"},
+      "past_simple": {"yo": "viví", "tú": "viviste", "vos": "viviste", "él": "vivió", "nosotros": "vivimos", "vosotros": "vivisteis", "ellos": "vivieron"},
+      "present_perfect": {"yo": "he vivido", "tú": "has vivido", "vos": "has vivido", "él": "ha vivido", "nosotros": "hemos vivido", "vosotros": "habéis vivido", "ellos": "han vivido"},
+      "future_simple": {"yo": "viviré", "tú": "vivirás", "vos": "vivirás", "él": "vivirá", "nosotros": "viviremos", "vosotros": "viviréis", "ellos": "vivirán"},
+      "condicional_simple": {"yo": "viviría", "tú": "vivirías", "vos": "vivirías", "él": "viviría", "nosotros": "viviríamos", "vosotros": "viviríais", "ellos": "vivirían"},
+      "imperfect_indicative": {"yo": "vivía", "tú": "vivías", "vos": "vivías", "él": "vivía", "nosotros": "vivíamos", "vosotros": "vivíais", "ellos": "vivían"}
     },
     "conjugations_en": {
       "present": {"I": "live", "you": "live", "he": "lives", "she": "lives", "it": "lives", "we": "live", "they": "live"},
@@ -95,12 +95,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "estudio", "tú": "estudias", "él": "estudia", "nosotros": "estudiamos", "vosotros": "estudiáis", "ellos": "estudian"},
-      "past_simple": {"yo": "estudié", "tú": "estudiaste", "él": "estudió", "nosotros": "estudiamos", "vosotros": "estudiasteis", "ellos": "estudiaron"},
-      "present_perfect": {"yo": "he estudiado", "tú": "has estudiado", "él": "ha estudiado", "nosotros": "hemos estudiado", "vosotros": "habéis estudiado", "ellos": "han estudiado"},
-      "future_simple": {"yo": "estudiaré", "tú": "estudiarás", "él": "estudiará", "nosotros": "estudiaremos", "vosotros": "estudiaréis", "ellos": "estudiarán"},
-      "condicional_simple": {"yo": "estudiaría", "tú": "estudiarías", "él": "estudiaría", "nosotros": "estudiaríamos", "vosotros": "estudiaríais", "ellos": "estudiarían"},
-      "imperfect_indicative": {"yo": "estudiaba", "tú": "estudiabas", "él": "estudiaba", "nosotros": "estudiábamos", "vosotros": "estudiabais", "ellos": "estudiaban"}
+      "present": {"yo": "estudio", "tú": "estudias", "vos": "estudiás", "él": "estudia", "nosotros": "estudiamos", "vosotros": "estudiáis", "ellos": "estudian"},
+      "past_simple": {"yo": "estudié", "tú": "estudiaste", "vos": "estudiaste", "él": "estudió", "nosotros": "estudiamos", "vosotros": "estudiasteis", "ellos": "estudiaron"},
+      "present_perfect": {"yo": "he estudiado", "tú": "has estudiado", "vos": "has estudiado", "él": "ha estudiado", "nosotros": "hemos estudiado", "vosotros": "habéis estudiado", "ellos": "han estudiado"},
+      "future_simple": {"yo": "estudiaré", "tú": "estudiarás", "vos": "estudiarás", "él": "estudiará", "nosotros": "estudiaremos", "vosotros": "estudiaréis", "ellos": "estudiarán"},
+      "condicional_simple": {"yo": "estudiaría", "tú": "estudiarías", "vos": "estudiarías", "él": "estudiaría", "nosotros": "estudiaríamos", "vosotros": "estudiaríais", "ellos": "estudiarían"},
+      "imperfect_indicative": {"yo": "estudiaba", "tú": "estudiabas", "vos": "estudiabas", "él": "estudiaba", "nosotros": "estudiábamos", "vosotros": "estudiabais", "ellos": "estudiaban"}
     },
     "conjugations_en": {
       "present": {"I": "study", "you": "study", "he": "studies", "she": "studies", "it": "studies", "we": "study", "they": "study"},
@@ -123,12 +123,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "trabajo", "tú": "trabajas", "él": "trabaja", "nosotros": "trabajamos", "vosotros": "trabajáis", "ellos": "trabajan"},
-      "past_simple": {"yo": "trabajé", "tú": "trabajaste", "él": "trabajó", "nosotros": "trabajamos", "vosotros": "trabajasteis", "ellos": "trabajaron"},
-      "present_perfect": {"yo": "he trabajado", "tú": "has trabajado", "él": "ha trabajado", "nosotros": "hemos trabajado", "vosotros": "habéis trabajado", "ellos": "han trabajado"},
-      "future_simple": {"yo": "trabajaré", "tú": "trabajarás", "él": "trabajará", "nosotros": "trabajaremos", "vosotros": "trabajaréis", "ellos": "trabajarán"},
-      "condicional_simple": {"yo": "trabajaría", "tú": "trabajarías", "él": "trabajaría", "nosotros": "trabajaríamos", "vosotros": "trabajaríais", "ellos": "trabajarían"},
-      "imperfect_indicative": {"yo": "trabajaba", "tú": "trabajabas", "él": "trabajaba", "nosotros": "trabajábamos", "vosotros": "trabajabais", "ellos": "trabajaban"}
+      "present": {"yo": "trabajo", "tú": "trabajas", "vos": "trabajás", "él": "trabaja", "nosotros": "trabajamos", "vosotros": "trabajáis", "ellos": "trabajan"},
+      "past_simple": {"yo": "trabajé", "tú": "trabajaste", "vos": "trabajaste", "él": "trabajó", "nosotros": "trabajamos", "vosotros": "trabajasteis", "ellos": "trabajaron"},
+      "present_perfect": {"yo": "he trabajado", "tú": "has trabajado", "vos": "has trabajado", "él": "ha trabajado", "nosotros": "hemos trabajado", "vosotros": "habéis trabajado", "ellos": "han trabajado"},
+      "future_simple": {"yo": "trabajaré", "tú": "trabajarás", "vos": "trabajarás", "él": "trabajará", "nosotros": "trabajaremos", "vosotros": "trabajaréis", "ellos": "trabajarán"},
+      "condicional_simple": {"yo": "trabajaría", "tú": "trabajarías", "vos": "trabajarías", "él": "trabajaría", "nosotros": "trabajaríamos", "vosotros": "trabajaríais", "ellos": "trabajarían"},
+      "imperfect_indicative": {"yo": "trabajaba", "tú": "trabajabas", "vos": "trabajabas", "él": "trabajaba", "nosotros": "trabajábamos", "vosotros": "trabajabais", "ellos": "trabajaban"}
     },
     "conjugations_en": {
       "present": {"I": "work", "you": "work", "he": "works", "she": "works", "it": "works", "we": "work", "they": "work"},
@@ -151,12 +151,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "aprendo", "tú": "aprendes", "él": "aprende", "nosotros": "aprendemos", "vosotros": "aprendéis", "ellos": "aprenden"},
-      "past_simple": {"yo": "aprendí", "tú": "aprendiste", "él": "aprendió", "nosotros": "aprendimos", "vosotros": "aprendisteis", "ellos": "aprendieron"},
-      "present_perfect": {"yo": "he aprendido", "tú": "has aprendido", "él": "ha aprendido", "nosotros": "hemos aprendido", "vosotros": "habéis aprendido", "ellos": "han aprendido"},
-      "future_simple": {"yo": "aprenderé", "tú": "aprenderás", "él": "aprenderá", "nosotros": "aprenderemos", "vosotros": "aprenderéis", "ellos": "aprenderán"},
-      "condicional_simple": {"yo": "aprendería", "tú": "aprenderías", "él": "aprendería", "nosotros": "aprenderíamos", "vosotros": "aprenderíais", "ellos": "aprenderían"},
-      "imperfect_indicative": {"yo": "aprendía", "tú": "aprendías", "él": "aprendía", "nosotros": "aprendíamos", "vosotros": "aprendíais", "ellos": "aprendían"}
+      "present": {"yo": "aprendo", "tú": "aprendes", "vos": "aprendés", "él": "aprende", "nosotros": "aprendemos", "vosotros": "aprendéis", "ellos": "aprenden"},
+      "past_simple": {"yo": "aprendí", "tú": "aprendiste", "vos": "aprendiste", "él": "aprendió", "nosotros": "aprendimos", "vosotros": "aprendisteis", "ellos": "aprendieron"},
+      "present_perfect": {"yo": "he aprendido", "tú": "has aprendido", "vos": "has aprendido", "él": "ha aprendido", "nosotros": "hemos aprendido", "vosotros": "habéis aprendido", "ellos": "han aprendido"},
+      "future_simple": {"yo": "aprenderé", "tú": "aprenderás", "vos": "aprenderás", "él": "aprenderá", "nosotros": "aprenderemos", "vosotros": "aprenderéis", "ellos": "aprenderán"},
+      "condicional_simple": {"yo": "aprendería", "tú": "aprenderías", "vos": "aprenderías", "él": "aprendería", "nosotros": "aprenderíamos", "vosotros": "aprenderíais", "ellos": "aprenderían"},
+      "imperfect_indicative": {"yo": "aprendía", "tú": "aprendías", "vos": "aprendías", "él": "aprendía", "nosotros": "aprendíamos", "vosotros": "aprendíais", "ellos": "aprendían"}
     },
     "conjugations_en": {
       "present": {"I": "learn", "you": "learn", "he": "learns", "she": "learns", "it": "learns", "we": "learn", "they": "learn"},
@@ -179,12 +179,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "escribo", "tú": "escribes", "él": "escribe", "nosotros": "escribimos", "vosotros": "escribís", "ellos": "escriben"},
-      "past_simple": {"yo": "escribí", "tú": "escribiste", "él": "escribió", "nosotros": "escribimos", "vosotros": "escribisteis", "ellos": "escribieron"},
-      "present_perfect": {"yo": "he escrito", "tú": "has escrito", "él": "ha escrito", "nosotros": "hemos escrito", "vosotros": "habéis escrito", "ellos": "han escrito"},
-      "future_simple": {"yo": "escribiré", "tú": "escribirás", "él": "escribirá", "nosotros": "escribiremos", "vosotros": "escribiréis", "ellos": "escribirán"},
-      "condicional_simple": {"yo": "escribiría", "tú": "escribirías", "él": "escribiría", "nosotros": "escribiríamos", "vosotros": "escribiríais", "ellos": "escribirían"},
-      "imperfect_indicative": {"yo": "escribía", "tú": "escribías", "él": "escribía", "nosotros": "escribíamos", "vosotros": "escribíais", "ellos": "escribían"}
+      "present": {"yo": "escribo", "tú": "escribes", "vos": "escribís", "él": "escribe", "nosotros": "escribimos", "vosotros": "escribís", "ellos": "escriben"},
+      "past_simple": {"yo": "escribí", "tú": "escribiste", "vos": "escribiste", "él": "escribió", "nosotros": "escribimos", "vosotros": "escribisteis", "ellos": "escribieron"},
+      "present_perfect": {"yo": "he escrito", "tú": "has escrito", "vos": "has escrito", "él": "ha escrito", "nosotros": "hemos escrito", "vosotros": "habéis escrito", "ellos": "han escrito"},
+      "future_simple": {"yo": "escribiré", "tú": "escribirás", "vos": "escribirás", "él": "escribirá", "nosotros": "escribiremos", "vosotros": "escribiréis", "ellos": "escribirán"},
+      "condicional_simple": {"yo": "escribiría", "tú": "escribirías", "vos": "escribirías", "él": "escribiría", "nosotros": "escribiríamos", "vosotros": "escribiríais", "ellos": "escribirían"},
+      "imperfect_indicative": {"yo": "escribía", "tú": "escribías", "vos": "escribías", "él": "escribía", "nosotros": "escribíamos", "vosotros": "escribíais", "ellos": "escribían"}
     },
     "conjugations_en": {
       "present": {"I": "write", "you": "write", "he": "writes", "she": "writes", "it": "writes", "we": "write", "they": "write"},
@@ -207,12 +207,12 @@
       "imperfect_indicative": ["irregular_imperfect"]
     },
     "conjugations": {
-      "present": {"yo": "soy", "tú": "eres", "él": "es", "nosotros": "somos", "vosotros": "sois", "ellos": "son"},
-      "past_simple": {"yo": "fui", "tú": "fuiste", "él": "fue", "nosotros": "fuimos", "vosotros": "fuisteis", "ellos": "fueron"},
-      "present_perfect": {"yo": "he sido", "tú": "has sido", "él": "ha sido", "nosotros": "hemos sido", "vosotros": "habéis sido", "ellos": "han sido"},
-      "future_simple": {"yo": "seré", "tú": "serás", "él": "será", "nosotros": "seremos", "vosotros": "seréis", "ellos": "serán"},
-      "condicional_simple": {"yo": "sería", "tú": "serías", "él": "sería", "nosotros": "seríamos", "vosotros": "seríais", "ellos": "serían"},
-      "imperfect_indicative": {"yo": "era", "tú": "eras", "él": "era", "nosotros": "éramos", "vosotros": "erais", "ellos": "eran"}
+      "present": {"yo": "soy", "tú": "eres", "vos": "sos", "él": "es", "nosotros": "somos", "vosotros": "sois", "ellos": "son"},
+      "past_simple": {"yo": "fui", "tú": "fuiste", "vos": "fuiste", "él": "fue", "nosotros": "fuimos", "vosotros": "fuisteis", "ellos": "fueron"},
+      "present_perfect": {"yo": "he sido", "tú": "has sido", "vos": "has sido", "él": "ha sido", "nosotros": "hemos sido", "vosotros": "habéis sido", "ellos": "han sido"},
+      "future_simple": {"yo": "seré", "tú": "serás", "vos": "serás", "él": "será", "nosotros": "seremos", "vosotros": "seréis", "ellos": "serán"},
+      "condicional_simple": {"yo": "sería", "tú": "serías", "vos": "serías", "él": "sería", "nosotros": "seríamos", "vosotros": "seríais", "ellos": "serían"},
+      "imperfect_indicative": {"yo": "era", "tú": "eras", "vos": "eras", "él": "era", "nosotros": "éramos", "vosotros": "erais", "ellos": "eran"}
     },
     "conjugations_en": {
       "present": {"I": "am", "you": "are", "he": "is", "she": "is", "it": "is", "we": "are", "they": "are"},
@@ -235,12 +235,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "estoy", "tú": "estás", "él": "está", "nosotros": "estamos", "vosotros": "estáis", "ellos": "están"},
-      "past_simple": {"yo": "estuve", "tú": "estuviste", "él": "estuvo", "nosotros": "estuvimos", "vosotros": "estuvisteis", "ellos": "estuvieron"},
-      "present_perfect": {"yo": "he estado", "tú": "has estado", "él": "ha estado", "nosotros": "hemos estado", "vosotros": "habéis estado", "ellos": "han estado"},
-      "future_simple": {"yo": "estaré", "tú": "estarás", "él": "estará", "nosotros": "estaremos", "vosotros": "estaréis", "ellos": "estarán"},
-      "condicional_simple": {"yo": "estaría", "tú": "estarías", "él": "estaría", "nosotros": "estaríamos", "vosotros": "estaríais", "ellos": "estarían"},
-      "imperfect_indicative": {"yo": "estaba", "tú": "estabas", "él": "estaba", "nosotros": "estábamos", "vosotros": "estabais", "ellos": "estaban"}
+      "present": {"yo": "estoy", "tú": "estás", "vos": "estás", "él": "está", "nosotros": "estamos", "vosotros": "estáis", "ellos": "están"},
+      "past_simple": {"yo": "estuve", "tú": "estuviste", "vos": "estuviste", "él": "estuvo", "nosotros": "estuvimos", "vosotros": "estuvisteis", "ellos": "estuvieron"},
+      "present_perfect": {"yo": "he estado", "tú": "has estado", "vos": "has estado", "él": "ha estado", "nosotros": "hemos estado", "vosotros": "habéis estado", "ellos": "han estado"},
+      "future_simple": {"yo": "estaré", "tú": "estarás", "vos": "estarás", "él": "estará", "nosotros": "estaremos", "vosotros": "estaréis", "ellos": "estarán"},
+      "condicional_simple": {"yo": "estaría", "tú": "estarías", "vos": "estarías", "él": "estaría", "nosotros": "estaríamos", "vosotros": "estaríais", "ellos": "estarían"},
+      "imperfect_indicative": {"yo": "estaba", "tú": "estabas", "vos": "estabas", "él": "estaba", "nosotros": "estábamos", "vosotros": "estabais", "ellos": "estaban"}
     },
     "conjugations_en": {
       "present": {"I": "am", "you": "are", "he": "is", "she": "is", "it": "is", "we": "are", "they": "are"},
@@ -263,12 +263,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "tengo", "tú": "tienes", "él": "tiene", "nosotros": "tenemos", "vosotros": "tenéis", "ellos": "tienen"},
-      "past_simple": {"yo": "tuve", "tú": "tuviste", "él": "tuvo", "nosotros": "tuvimos", "vosotros": "tuvisteis", "ellos": "tuvieron"},
-      "present_perfect": {"yo": "he tenido", "tú": "has tenido", "él": "ha tenido", "nosotros": "hemos tenido", "vosotros": "habéis tenido", "ellos": "han tenido"},
-      "future_simple": {"yo": "tendré", "tú": "tendrás", "él": "tendrá", "nosotros": "tendremos", "vosotros": "tendréis", "ellos": "tendrán"},
-      "condicional_simple": {"yo": "tendría", "tú": "tendrías", "él": "tendría", "nosotros": "tendríamos", "vosotros": "tendríais", "ellos": "tendrían"},
-      "imperfect_indicative": {"yo": "tenía", "tú": "tenías", "él": "tenía", "nosotros": "teníamos", "vosotros": "teníais", "ellos": "tenían"}
+      "present": {"yo": "tengo", "tú": "tienes", "vos": "tenés", "él": "tiene", "nosotros": "tenemos", "vosotros": "tenéis", "ellos": "tienen"},
+      "past_simple": {"yo": "tuve", "tú": "tuviste", "vos": "tuviste", "él": "tuvo", "nosotros": "tuvimos", "vosotros": "tuvisteis", "ellos": "tuvieron"},
+      "present_perfect": {"yo": "he tenido", "tú": "has tenido", "vos": "has tenido", "él": "ha tenido", "nosotros": "hemos tenido", "vosotros": "habéis tenido", "ellos": "han tenido"},
+      "future_simple": {"yo": "tendré", "tú": "tendrás", "vos": "tendrás", "él": "tendrá", "nosotros": "tendremos", "vosotros": "tendréis", "ellos": "tendrán"},
+      "condicional_simple": {"yo": "tendría", "tú": "tendrías", "vos": "tendrías", "él": "tendría", "nosotros": "tendríamos", "vosotros": "tendríais", "ellos": "tendrían"},
+      "imperfect_indicative": {"yo": "tenía", "tú": "tenías", "vos": "tenías", "él": "tenía", "nosotros": "teníamos", "vosotros": "teníais", "ellos": "tenían"}
     },
     "conjugations_en": {
       "present": {"I": "have", "you": "have", "he": "has", "she": "has", "it": "has", "we": "have", "they": "have"},
@@ -291,12 +291,12 @@
       "imperfect_indicative": ["irregular"]
     },
     "conjugations": {
-      "present": {"yo": "voy", "tú": "vas", "él": "va", "nosotros": "vamos", "vosotros": "vais", "ellos": "van"},
-      "past_simple": {"yo": "fui", "tú": "fuiste", "él": "fue", "nosotros": "fuimos", "vosotros": "fuisteis", "ellos": "fueron"},
-      "present_perfect": {"yo": "he ido", "tú": "has ido", "él": "ha ido", "nosotros": "hemos ido", "vosotros": "habéis ido", "ellos": "han ido"},
-      "future_simple": {"yo": "iré", "tú": "irás", "él": "irá", "nosotros": "iremos", "vosotros": "iréis", "ellos": "irán"},
-      "condicional_simple": {"yo": "iría", "tú": "irías", "él": "iría", "nosotros": "iríamos", "vosotros": "iríais", "ellos": "irían"},
-      "imperfect_indicative": {"yo": "iba", "tú": "ibas", "él": "iba", "nosotros": "íbamos", "vosotros": "ibais", "ellos": "iban"}
+      "present": {"yo": "voy", "tú": "vas", "vos": "vas", "él": "va", "nosotros": "vamos", "vosotros": "vais", "ellos": "van"},
+      "past_simple": {"yo": "fui", "tú": "fuiste", "vos": "fuiste", "él": "fue", "nosotros": "fuimos", "vosotros": "fuisteis", "ellos": "fueron"},
+      "present_perfect": {"yo": "he ido", "tú": "has ido", "vos": "has ido", "él": "ha ido", "nosotros": "hemos ido", "vosotros": "habéis ido", "ellos": "han ido"},
+      "future_simple": {"yo": "iré", "tú": "irás", "vos": "irás", "él": "irá", "nosotros": "iremos", "vosotros": "iréis", "ellos": "irán"},
+      "condicional_simple": {"yo": "iría", "tú": "irías", "vos": "irías", "él": "iría", "nosotros": "iríamos", "vosotros": "iríais", "ellos": "irían"},
+      "imperfect_indicative": {"yo": "iba", "tú": "ibas", "vos": "ibas", "él": "iba", "nosotros": "íbamos", "vosotros": "ibais", "ellos": "iban"}
     },
     "conjugations_en": {
       "present": {"I": "go", "you": "go", "he": "goes", "she": "goes", "it": "goes", "we": "go", "they": "go"},
@@ -319,12 +319,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "siento", "tú": "sientes", "él": "siente", "nosotros": "sentimos", "vosotros": "sentís", "ellos": "sienten"},
-      "past_simple": {"yo": "sentí", "tú": "sentiste", "él": "sintió", "nosotros": "sentimos", "vosotros": "sentisteis", "ellos": "sintieron"},
-      "present_perfect": {"yo": "he sentido", "tú": "has sentido", "él": "ha sentido", "nosotros": "hemos sentido", "vosotros": "habéis sentido", "ellos": "han sentido"},
-      "future_simple": {"yo": "sentiré", "tú": "sentirás", "él": "sentirá", "nosotros": "sentiremos", "vosotros": "sentiréis", "ellos": "sentirán"},
-      "condicional_simple": {"yo": "sentiría", "tú": "sentirías", "él": "sentiría", "nosotros": "sentiríamos", "vosotros": "sentiríais", "ellos": "sentirían"},
-      "imperfect_indicative": {"yo": "sentía", "tú": "sentías", "él": "sentía", "nosotros": "sentíamos", "vosotros": "sentíais", "ellos": "sentían"}
+      "present": {"yo": "siento", "tú": "sientes", "vos": "sentís", "él": "siente", "nosotros": "sentimos", "vosotros": "sentís", "ellos": "sienten"},
+      "past_simple": {"yo": "sentí", "tú": "sentiste", "vos": "sentiste", "él": "sintió", "nosotros": "sentimos", "vosotros": "sentisteis", "ellos": "sintieron"},
+      "present_perfect": {"yo": "he sentido", "tú": "has sentido", "vos": "has sentido", "él": "ha sentido", "nosotros": "hemos sentido", "vosotros": "habéis sentido", "ellos": "han sentido"},
+      "future_simple": {"yo": "sentiré", "tú": "sentirás", "vos": "sentirás", "él": "sentirá", "nosotros": "sentiremos", "vosotros": "sentiréis", "ellos": "sentirán"},
+      "condicional_simple": {"yo": "sentiría", "tú": "sentirías", "vos": "sentirías", "él": "sentiría", "nosotros": "sentiríamos", "vosotros": "sentiríais", "ellos": "sentirían"},
+      "imperfect_indicative": {"yo": "sentía", "tú": "sentías", "vos": "sentías", "él": "sentía", "nosotros": "sentíamos", "vosotros": "sentíais", "ellos": "sentían"}
     },
     "conjugations_en": {
       "present": {"I": "feel", "you": "feel", "he": "feels", "she": "feels", "it": "feels", "we": "feel", "they": "feel"},
@@ -347,12 +347,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "duermo", "tú": "duermes", "él": "duerme", "nosotros": "dormimos", "vosotros": "dormís", "ellos": "duermen"},
-      "past_simple": {"yo": "dormí", "tú": "dormiste", "él": "durmió", "nosotros": "dormimos", "vosotros": "dormisteis", "ellos": "durmieron"},
-      "present_perfect": {"yo": "he dormido", "tú": "has dormido", "él": "ha dormido", "nosotros": "hemos dormido", "vosotros": "habéis dormido", "ellos": "han dormido"},
-      "future_simple": {"yo": "dormiré", "tú": "dormirás", "él": "dormirá", "nosotros": "dormiremos", "vosotros": "dormiréis", "ellos": "dormirán"},
-      "condicional_simple": {"yo": "dormiría", "tú": "dormirías", "él": "dormiría", "nosotros": "dormiríamos", "vosotros": "dormiríais", "ellos": "dormirían"},
-      "imperfect_indicative": {"yo": "dormía", "tú": "dormías", "él": "dormía", "nosotros": "dormíamos", "vosotros": "dormíais", "ellos": "dormían"}
+      "present": {"yo": "duermo", "tú": "duermes", "vos": "dormís", "él": "duerme", "nosotros": "dormimos", "vosotros": "dormís", "ellos": "duermen"},
+      "past_simple": {"yo": "dormí", "tú": "dormiste", "vos": "dormiste", "él": "durmió", "nosotros": "dormimos", "vosotros": "dormisteis", "ellos": "durmieron"},
+      "present_perfect": {"yo": "he dormido", "tú": "has dormido", "vos": "has dormido", "él": "ha dormido", "nosotros": "hemos dormido", "vosotros": "habéis dormido", "ellos": "han dormido"},
+      "future_simple": {"yo": "dormiré", "tú": "dormirás", "vos": "dormirás", "él": "dormirá", "nosotros": "dormiremos", "vosotros": "dormiréis", "ellos": "dormirán"},
+      "condicional_simple": {"yo": "dormiría", "tú": "dormirías", "vos": "dormirías", "él": "dormiría", "nosotros": "dormiríamos", "vosotros": "dormiríais", "ellos": "dormirían"},
+      "imperfect_indicative": {"yo": "dormía", "tú": "dormías", "vos": "dormías", "él": "dormía", "nosotros": "dormíamos", "vosotros": "dormíais", "ellos": "dormían"}
     },
     "conjugations_en": {
       "present": {"I": "sleep", "you": "sleep", "he": "sleeps", "she": "sleeps", "it": "sleeps", "we": "sleep", "they": "sleep"},
@@ -375,12 +375,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "juego", "tú": "juegas", "él": "juega", "nosotros": "jugamos", "vosotros": "jugáis", "ellos": "juegan"},
-      "past_simple": {"yo": "jugué", "tú": "jugaste", "él": "jugó", "nosotros": "jugamos", "vosotros": "jugasteis", "ellos": "jugaron"},
-      "present_perfect": {"yo": "he jugado", "tú": "has jugado", "él": "ha jugado", "nosotros": "hemos jugado", "vosotros": "habéis jugado", "ellos": "han jugado"},
-      "future_simple": {"yo": "jugaré", "tú": "jugarás", "él": "jugará", "nosotros": "jugaremos", "vosotros": "jugaréis", "ellos": "jugarán"},
-      "condicional_simple": {"yo": "jugaría", "tú": "jugarías", "él": "jugaría", "nosotros": "jugaríamos", "vosotros": "jugaríais", "ellos": "jugarían"},
-      "imperfect_indicative": {"yo": "jugaba", "tú": "jugabas", "él": "jugaba", "nosotros": "jugábamos", "vosotros": "jugabais", "ellos": "jugaban"}
+      "present": {"yo": "juego", "tú": "juegas", "vos": "jugás", "él": "juega", "nosotros": "jugamos", "vosotros": "jugáis", "ellos": "juegan"},
+      "past_simple": {"yo": "jugué", "tú": "jugaste", "vos": "jugaste", "él": "jugó", "nosotros": "jugamos", "vosotros": "jugasteis", "ellos": "jugaron"},
+      "present_perfect": {"yo": "he jugado", "tú": "has jugado", "vos": "has jugado", "él": "ha jugado", "nosotros": "hemos jugado", "vosotros": "habéis jugado", "ellos": "han jugado"},
+      "future_simple": {"yo": "jugaré", "tú": "jugarás", "vos": "jugarás", "él": "jugará", "nosotros": "jugaremos", "vosotros": "jugaréis", "ellos": "jugarán"},
+      "condicional_simple": {"yo": "jugaría", "tú": "jugarías", "vos": "jugarías", "él": "jugaría", "nosotros": "jugaríamos", "vosotros": "jugaríais", "ellos": "jugarían"},
+      "imperfect_indicative": {"yo": "jugaba", "tú": "jugabas", "vos": "jugabas", "él": "jugaba", "nosotros": "jugábamos", "vosotros": "jugabais", "ellos": "jugaban"}
     },
     "conjugations_en": {
       "present": {"I": "play", "you": "play", "he": "plays", "she": "plays", "it": "plays", "we": "play", "they": "play"},
@@ -403,12 +403,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "sigo", "tú": "sigues", "él": "sigue", "nosotros": "seguimos", "vosotros": "seguís", "ellos": "siguen"},
-      "past_simple": {"yo": "seguí", "tú": "seguiste", "él": "siguió", "nosotros": "seguimos", "vosotros": "seguisteis", "ellos": "siguieron"},
-      "present_perfect": {"yo": "he seguido", "tú": "has seguido", "él": "ha seguido", "nosotros": "hemos seguido", "vosotros": "habéis seguido", "ellos": "han seguido"},
-      "future_simple": {"yo": "seguiré", "tú": "seguirás", "él": "seguirá", "nosotros": "seguiremos", "vosotros": "seguiréis", "ellos": "seguirán"},
-      "condicional_simple": {"yo": "seguiría", "tú": "seguirías", "él": "seguiría", "nosotros": "seguiríamos", "vosotros": "seguiríais", "ellos": "seguirían"},
-      "imperfect_indicative": {"yo": "seguía", "tú": "seguías", "él": "seguía", "nosotros": "seguíamos", "vosotros": "seguíais", "ellos": "seguían"}
+      "present": {"yo": "sigo", "tú": "sigues", "vos": "seguís", "él": "sigue", "nosotros": "seguimos", "vosotros": "seguís", "ellos": "siguen"},
+      "past_simple": {"yo": "seguí", "tú": "seguiste", "vos": "seguiste", "él": "siguió", "nosotros": "seguimos", "vosotros": "seguisteis", "ellos": "siguieron"},
+      "present_perfect": {"yo": "he seguido", "tú": "has seguido", "vos": "has seguido", "él": "ha seguido", "nosotros": "hemos seguido", "vosotros": "habéis seguido", "ellos": "han seguido"},
+      "future_simple": {"yo": "seguiré", "tú": "seguirás", "vos": "seguirás", "él": "seguirá", "nosotros": "seguiremos", "vosotros": "seguiréis", "ellos": "seguirán"},
+      "condicional_simple": {"yo": "seguiría", "tú": "seguirías", "vos": "seguirías", "él": "seguiría", "nosotros": "seguiríamos", "vosotros": "seguiríais", "ellos": "seguirían"},
+      "imperfect_indicative": {"yo": "seguía", "tú": "seguías", "vos": "seguías", "él": "seguía", "nosotros": "seguíamos", "vosotros": "seguíais", "ellos": "seguían"}
     },
     "conjugations_en": {
       "present": {"I": "follow", "you": "follow", "he": "follows", "she": "follows", "it": "follows", "we": "follow", "they": "follow"},
@@ -431,12 +431,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "vuelvo", "tú": "vuelves", "él": "vuelve", "nosotros": "volvemos", "vosotros": "volvéis", "ellos": "vuelven"},
-      "past_simple": {"yo": "volví", "tú": "volviste", "él": "volvió", "nosotros": "volvimos", "vosotros": "volvisteis", "ellos": "volvieron"},
-      "present_perfect": {"yo": "he vuelto", "tú": "has vuelto", "él": "ha vuelto", "nosotros": "hemos vuelto", "vosotros": "habéis vuelto", "ellos": "han vuelto"},
-      "future_simple": {"yo": "volveré", "tú": "volverás", "él": "volverá", "nosotros": "volveremos", "vosotros": "volveréis", "ellos": "volverán"},
-      "condicional_simple": {"yo": "volvería", "tú": "volverías", "él": "volvería", "nosotros": "volveríamos", "vosotros": "volveríais", "ellos": "volverían"},
-      "imperfect_indicative": {"yo": "volvía", "tú": "volvías", "él": "volvía", "nosotros": "volvíamos", "vosotros": "volvíais", "ellos": "volvían"}
+      "present": {"yo": "vuelvo", "tú": "vuelves", "vos": "volvés", "él": "vuelve", "nosotros": "volvemos", "vosotros": "volvéis", "ellos": "vuelven"},
+      "past_simple": {"yo": "volví", "tú": "volviste", "vos": "volviste", "él": "volvió", "nosotros": "volvimos", "vosotros": "volvisteis", "ellos": "volvieron"},
+      "present_perfect": {"yo": "he vuelto", "tú": "has vuelto", "vos": "has vuelto", "él": "ha vuelto", "nosotros": "hemos vuelto", "vosotros": "habéis vuelto", "ellos": "han vuelto"},
+      "future_simple": {"yo": "volveré", "tú": "volverás", "vos": "volverás", "él": "volverá", "nosotros": "volveremos", "vosotros": "volveréis", "ellos": "volverán"},
+      "condicional_simple": {"yo": "volvería", "tú": "volverías", "vos": "volverías", "él": "volvería", "nosotros": "volveríamos", "vosotros": "volveríais", "ellos": "volverían"},
+      "imperfect_indicative": {"yo": "volvía", "tú": "volvías", "vos": "volvías", "él": "volvía", "nosotros": "volvíamos", "vosotros": "volvíais", "ellos": "volvían"}
     },
     "conjugations_en": {
       "present": {"I": "come back", "you": "come back", "he": "comes back", "she": "comes back", "it": "comes back", "we": "come back", "they": "come back"},
@@ -459,12 +459,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "construyo", "tú": "construyes", "él": "construye", "nosotros": "construimos", "vosotros": "construís", "ellos": "construyen"},
-      "past_simple": {"yo": "construí", "tú": "construiste", "él": "construyó", "nosotros": "construimos", "vosotros": "construisteis", "ellos": "construyeron"},
-      "present_perfect": {"yo": "he construido", "tú": "has construido", "él": "ha construido", "nosotros": "hemos construido", "vosotros": "habéis construido", "ellos": "han construido"},
-      "future_simple": {"yo": "construiré", "tú": "construirás", "él": "construirá", "nosotros": "construiremos", "vosotros": "construiréis", "ellos": "construirán"},
-      "condicional_simple": {"yo": "construiría", "tú": "construirías", "él": "construiría", "nosotros": "construiríamos", "vosotros": "construiríais", "ellos": "construirían"},
-      "imperfect_indicative": {"yo": "construía", "tú": "construías", "él": "construía", "nosotros": "construíamos", "vosotros": "construíais", "ellos": "construían"}
+      "present": {"yo": "construyo", "tú": "construyes", "vos": "construís", "él": "construye", "nosotros": "construimos", "vosotros": "construís", "ellos": "construyen"},
+      "past_simple": {"yo": "construí", "tú": "construiste", "vos": "construiste", "él": "construyó", "nosotros": "construimos", "vosotros": "construisteis", "ellos": "construyeron"},
+      "present_perfect": {"yo": "he construido", "tú": "has construido", "vos": "has construido", "él": "ha construido", "nosotros": "hemos construido", "vosotros": "habéis construido", "ellos": "han construido"},
+      "future_simple": {"yo": "construiré", "tú": "construirás", "vos": "construirás", "él": "construirá", "nosotros": "construiremos", "vosotros": "construiréis", "ellos": "construirán"},
+      "condicional_simple": {"yo": "construiría", "tú": "construirías", "vos": "construirías", "él": "construiría", "nosotros": "construiríamos", "vosotros": "construiríais", "ellos": "construirían"},
+      "imperfect_indicative": {"yo": "construía", "tú": "construías", "vos": "construías", "él": "construía", "nosotros": "construíamos", "vosotros": "construíais", "ellos": "construían"}
     },
     "conjugations_en": {
       "present": {"I": "build", "you": "build", "he": "builds", "she": "builds", "it": "builds", "we": "build", "they": "build"},
@@ -487,12 +487,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "salgo", "tú": "sales", "él": "sale", "nosotros": "salimos", "vosotros": "salís", "ellos": "salen"},
-      "past_simple": {"yo": "salí", "tú": "saliste", "él": "salió", "nosotros": "salimos", "vosotros": "salisteis", "ellos": "salieron"},
-      "present_perfect": {"yo": "he salido", "tú": "has salido", "él": "ha salido", "nosotros": "hemos salido", "vosotros": "habéis salido", "ellos": "han salido"},
-      "future_simple": {"yo": "saldré", "tú": "saldrás", "él": "saldrá", "nosotros": "saldremos", "vosotros": "saldréis", "ellos": "saldrán"},
-      "condicional_simple": {"yo": "saldría", "tú": "saldrías", "él": "saldría", "nosotros": "saldríamos", "vosotros": "saldríais", "ellos": "saldrían"},
-      "imperfect_indicative": {"yo": "salía", "tú": "salías", "él": "salía", "nosotros": "salíamos", "vosotros": "salíais", "ellos": "salían"}
+      "present": {"yo": "salgo", "tú": "sales", "vos": "salís", "él": "sale", "nosotros": "salimos", "vosotros": "salís", "ellos": "salen"},
+      "past_simple": {"yo": "salí", "tú": "saliste", "vos": "saliste", "él": "salió", "nosotros": "salimos", "vosotros": "salisteis", "ellos": "salieron"},
+      "present_perfect": {"yo": "he salido", "tú": "has salido", "vos": "has salido", "él": "ha salido", "nosotros": "hemos salido", "vosotros": "habéis salido", "ellos": "han salido"},
+      "future_simple": {"yo": "saldré", "tú": "saldrás", "vos": "saldrás", "él": "saldrá", "nosotros": "saldremos", "vosotros": "saldréis", "ellos": "saldrán"},
+      "condicional_simple": {"yo": "saldría", "tú": "saldrías", "vos": "saldrías", "él": "saldría", "nosotros": "saldríamos", "vosotros": "saldríais", "ellos": "saldrían"},
+      "imperfect_indicative": {"yo": "salía", "tú": "salías", "vos": "salías", "él": "salía", "nosotros": "salíamos", "vosotros": "salíais", "ellos": "salían"}
     },
     "conjugations_en": {
       "present": {"I": "exit", "you": "exit", "he": "exits", "she": "exits", "it": "exits", "we": "exit", "they": "exit"},
@@ -515,12 +515,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "sé", "tú": "sabes", "él": "sabe", "nosotros": "sabemos", "vosotros": "sabéis", "ellos": "saben"},
-      "past_simple": {"yo": "supe", "tú": "supiste", "él": "supo", "nosotros": "supimos", "vosotros": "supisteis", "ellos": "supieron"},
-      "present_perfect": {"yo": "he sabido", "tú": "has sabido", "él": "ha sabido", "nosotros": "hemos sabido", "vosotros": "habéis sabido", "ellos": "han sabido"},
-      "future_simple": {"yo": "sabré", "tú": "sabrás", "él": "sabrá", "nosotros": "sabremos", "vosotros": "sabréis", "ellos": "sabrán"},
-      "condicional_simple": {"yo": "sabría", "tú": "sabrías", "él": "sabría", "nosotros": "sabríamos", "vosotros": "sabríais", "ellos": "sabrían"},
-      "imperfect_indicative": {"yo": "sabía", "tú": "sabías", "él": "sabía", "nosotros": "sabíamos", "vosotros": "sabíais", "ellos": "sabían"}
+      "present": {"yo": "sé", "tú": "sabes", "vos": "sabés", "él": "sabe", "nosotros": "sabemos", "vosotros": "sabéis", "ellos": "saben"},
+      "past_simple": {"yo": "supe", "tú": "supiste", "vos": "supiste", "él": "supo", "nosotros": "supimos", "vosotros": "supisteis", "ellos": "supieron"},
+      "present_perfect": {"yo": "he sabido", "tú": "has sabido", "vos": "has sabido", "él": "ha sabido", "nosotros": "hemos sabido", "vosotros": "habéis sabido", "ellos": "han sabido"},
+      "future_simple": {"yo": "sabré", "tú": "sabrás", "vos": "sabrás", "él": "sabrá", "nosotros": "sabremos", "vosotros": "sabréis", "ellos": "sabrán"},
+      "condicional_simple": {"yo": "sabría", "tú": "sabrías", "vos": "sabrías", "él": "sabría", "nosotros": "sabríamos", "vosotros": "sabríais", "ellos": "sabrían"},
+      "imperfect_indicative": {"yo": "sabía", "tú": "sabías", "vos": "sabías", "él": "sabía", "nosotros": "sabíamos", "vosotros": "sabíais", "ellos": "sabían"}
     },
     "conjugations_en": {
       "present": {"I": "know", "you": "know", "he": "knows", "she": "knows", "it": "knows", "we": "know", "they": "know"},
@@ -543,12 +543,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "puedo", "tú": "puedes", "él": "puede", "nosotros": "podemos", "vosotros": "podéis", "ellos": "pueden"},
-      "past_simple": {"yo": "pude", "tú": "pudiste", "él": "pudo", "nosotros": "pudimos", "vosotros": "pudisteis", "ellos": "pudieron"},
-      "present_perfect": {"yo": "he podido", "tú": "has podido", "él": "ha podido", "nosotros": "hemos podido", "vosotros": "habéis podido", "ellos": "han podido"},
-      "future_simple": {"yo": "podré", "tú": "podrás", "él": "podrá", "nosotros": "podremos", "vosotros": "podréis", "ellos": "podrán"},
-      "condicional_simple": {"yo": "podría", "tú": "podrías", "él": "podría", "nosotros": "podríamos", "vosotros": "podríais", "ellos": "podrían"},
-      "imperfect_indicative": {"yo": "podía", "tú": "podías", "él": "podía", "nosotros": "podíamos", "vosotros": "podíais", "ellos": "podían"}
+      "present": {"yo": "puedo", "tú": "puedes", "vos": "podés", "él": "puede", "nosotros": "podemos", "vosotros": "podéis", "ellos": "pueden"},
+      "past_simple": {"yo": "pude", "tú": "pudiste", "vos": "pudiste", "él": "pudo", "nosotros": "pudimos", "vosotros": "pudisteis", "ellos": "pudieron"},
+      "present_perfect": {"yo": "he podido", "tú": "has podido", "vos": "has podido", "él": "ha podido", "nosotros": "hemos podido", "vosotros": "habéis podido", "ellos": "han podido"},
+      "future_simple": {"yo": "podré", "tú": "podrás", "vos": "podrás", "él": "podrá", "nosotros": "podremos", "vosotros": "podréis", "ellos": "podrán"},
+      "condicional_simple": {"yo": "podría", "tú": "podrías", "vos": "podrías", "él": "podría", "nosotros": "podríamos", "vosotros": "podríais", "ellos": "podrían"},
+      "imperfect_indicative": {"yo": "podía", "tú": "podías", "vos": "podías", "él": "podía", "nosotros": "podíamos", "vosotros": "podíais", "ellos": "podían"}
     },
     "conjugations_en": {
       "present": {"I": "can", "you": "can", "he": "can", "she": "can", "it": "can", "we": "can", "they": "can"},
@@ -571,12 +571,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "digo", "tú": "dices", "él": "dice", "nosotros": "decimos", "vosotros": "decís", "ellos": "dicen"},
-      "past_simple": {"yo": "dije", "tú": "dijiste", "él": "dijo", "nosotros": "dijimos", "vosotros": "dijisteis", "ellos": "dijeron"},
-      "present_perfect": {"yo": "he dicho", "tú": "has dicho", "él": "ha dicho", "nosotros": "hemos dicho", "vosotros": "habéis dicho", "ellos": "han dicho"},
-      "future_simple": {"yo": "diré", "tú": "dirás", "él": "dirá", "nosotros": "diremos", "vosotros": "diréis", "ellos": "dirán"},
-      "condicional_simple": {"yo": "diría", "tú": "dirías", "él": "diría", "nosotros": "diríamos", "vosotros": "diríais", "ellos": "dirían"},
-      "imperfect_indicative": {"yo": "decía", "tú": "decías", "él": "decía", "nosotros": "decíamos", "vosotros": "decíais", "ellos": "decían"}
+      "present": {"yo": "digo", "tú": "dices", "vos": "decís", "él": "dice", "nosotros": "decimos", "vosotros": "decís", "ellos": "dicen"},
+      "past_simple": {"yo": "dije", "tú": "dijiste", "vos": "dijiste", "él": "dijo", "nosotros": "dijimos", "vosotros": "dijisteis", "ellos": "dijeron"},
+      "present_perfect": {"yo": "he dicho", "tú": "has dicho", "vos": "has dicho", "él": "ha dicho", "nosotros": "hemos dicho", "vosotros": "habéis dicho", "ellos": "han dicho"},
+      "future_simple": {"yo": "diré", "tú": "dirás", "vos": "dirás", "él": "dirá", "nosotros": "diremos", "vosotros": "diréis", "ellos": "dirán"},
+      "condicional_simple": {"yo": "diría", "tú": "dirías", "vos": "dirías", "él": "diría", "nosotros": "diríamos", "vosotros": "diríais", "ellos": "dirían"},
+      "imperfect_indicative": {"yo": "decía", "tú": "decías", "vos": "decías", "él": "decía", "nosotros": "decíamos", "vosotros": "decíais", "ellos": "decían"}
     },
     "conjugations_en": {
       "present": {"I": "say", "you": "say", "he": "says", "she": "says", "it": "says", "we": "say", "they": "say"},
@@ -599,12 +599,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "vengo", "tú": "vienes", "él": "viene", "nosotros": "venimos", "vosotros": "venís", "ellos": "vienen"},
-      "past_simple": {"yo": "vine", "tú": "viniste", "él": "vino", "nosotros": "vinimos", "vosotros": "vinisteis", "ellos": "vinieron"},
-      "present_perfect": {"yo": "he venido", "tú": "has venido", "él": "ha venido", "nosotros": "hemos venido", "vosotros": "habéis venido", "ellos": "han venido"},
-      "future_simple": {"yo": "vendré", "tú": "vendrás", "él": "vendrá", "nosotros": "vendremos", "vosotros": "vendréis", "ellos": "vendrán"},
-      "condicional_simple": {"yo": "vendría", "tú": "vendrías", "él": "vendría", "nosotros": "vendríamos", "vosotros": "vendríais", "ellos": "vendrían"},
-      "imperfect_indicative": {"yo": "venía", "tú": "venías", "él": "venía", "nosotros": "veníamos", "vosotros": "veníais", "ellos": "venían"}
+      "present": {"yo": "vengo", "tú": "vienes", "vos": "venís", "él": "viene", "nosotros": "venimos", "vosotros": "venís", "ellos": "vienen"},
+      "past_simple": {"yo": "vine", "tú": "viniste", "vos": "viniste", "él": "vino", "nosotros": "vinimos", "vosotros": "vinisteis", "ellos": "vinieron"},
+      "present_perfect": {"yo": "he venido", "tú": "has venido", "vos": "has venido", "él": "ha venido", "nosotros": "hemos venido", "vosotros": "habéis venido", "ellos": "han venido"},
+      "future_simple": {"yo": "vendré", "tú": "vendrás", "vos": "vendrás", "él": "vendrá", "nosotros": "vendremos", "vosotros": "vendréis", "ellos": "vendrán"},
+      "condicional_simple": {"yo": "vendría", "tú": "vendrías", "vos": "vendrías", "él": "vendría", "nosotros": "vendríamos", "vosotros": "vendríais", "ellos": "vendrían"},
+      "imperfect_indicative": {"yo": "venía", "tú": "venías", "vos": "venías", "él": "venía", "nosotros": "veníamos", "vosotros": "veníais", "ellos": "venían"}
     },
     "conjugations_en": {
       "present": {"I": "come", "you": "come", "he": "comes", "she": "comes", "it": "comes", "we": "come", "they": "come"},
@@ -627,12 +627,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "pongo", "tú": "pones", "él": "pone", "nosotros": "ponemos", "vosotros": "ponéis", "ellos": "ponen"},
-      "past_simple": {"yo": "puse", "tú": "pusiste", "él": "puso", "nosotros": "pusimos", "vosotros": "pusisteis", "ellos": "pusieron"},
-      "present_perfect": {"yo": "he puesto", "tú": "has puesto", "él": "ha puesto", "nosotros": "hemos puesto", "vosotros": "habéis puesto", "ellos": "han puesto"},
-      "future_simple": {"yo": "pondré", "tú": "pondrás", "él": "pondrá", "nosotros": "pondremos", "vosotros": "pondréis", "ellos": "pondrán"},
-      "condicional_simple": {"yo": "pondría", "tú": "pondrías", "él": "pondría", "nosotros": "pondríamos", "vosotros": "pondríais", "ellos": "pondrían"},
-      "imperfect_indicative": {"yo": "ponía", "tú": "ponías", "él": "ponía", "nosotros": "poníamos", "vosotros": "poníais", "ellos": "ponían"}
+      "present": {"yo": "pongo", "tú": "pones", "vos": "ponés", "él": "pone", "nosotros": "ponemos", "vosotros": "ponéis", "ellos": "ponen"},
+      "past_simple": {"yo": "puse", "tú": "pusiste", "vos": "pusiste", "él": "puso", "nosotros": "pusimos", "vosotros": "pusisteis", "ellos": "pusieron"},
+      "present_perfect": {"yo": "he puesto", "tú": "has puesto", "vos": "has puesto", "él": "ha puesto", "nosotros": "hemos puesto", "vosotros": "habéis puesto", "ellos": "han puesto"},
+      "future_simple": {"yo": "pondré", "tú": "pondrás", "vos": "pondrás", "él": "pondrá", "nosotros": "pondremos", "vosotros": "pondréis", "ellos": "pondrán"},
+      "condicional_simple": {"yo": "pondría", "tú": "pondrías", "vos": "pondrías", "él": "pondría", "nosotros": "pondríamos", "vosotros": "pondríais", "ellos": "pondrían"},
+      "imperfect_indicative": {"yo": "ponía", "tú": "ponías", "vos": "ponías", "él": "ponía", "nosotros": "poníamos", "vosotros": "poníais", "ellos": "ponían"}
     },
     "conjugations_en": {
       "present": {"I": "put", "you": "put", "he": "puts", "she": "puts", "it": "puts", "we": "put", "they": "put"},
@@ -655,12 +655,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "conozco", "tú": "conoces", "él": "conoce", "nosotros": "conocemos", "vosotros": "conocéis", "ellos": "conocen"},
-      "past_simple": {"yo": "conocí", "tú": "conociste", "él": "conoció", "nosotros": "conocimos", "vosotros": "conocisteis", "ellos": "conocieron"},
-      "present_perfect": {"yo": "he conocido", "tú": "has conocido", "él": "ha conocido", "nosotros": "hemos conocido", "vosotros": "habéis conocido", "ellos": "han conocido"},
-      "future_simple": {"yo": "conoceré", "tú": "conocerás", "él": "conocerá", "nosotros": "conoceremos", "vosotros": "conoceréis", "ellos": "conocerán"},
-      "condicional_simple": {"yo": "conocería", "tú": "conocerías", "él": "conocería", "nosotros": "conoceríamos", "vosotros": "conoceríais", "ellos": "conocerían"},
-      "imperfect_indicative": {"yo": "conocía", "tú": "conocías", "él": "conocía", "nosotros": "conocíamos", "vosotros": "conocíais", "ellos": "conocían"}
+      "present": {"yo": "conozco", "tú": "conoces", "vos": "conocés", "él": "conoce", "nosotros": "conocemos", "vosotros": "conocéis", "ellos": "conocen"},
+      "past_simple": {"yo": "conocí", "tú": "conociste", "vos": "conociste", "él": "conoció", "nosotros": "conocimos", "vosotros": "conocisteis", "ellos": "conocieron"},
+      "present_perfect": {"yo": "he conocido", "tú": "has conocido", "vos": "has conocido", "él": "ha conocido", "nosotros": "hemos conocido", "vosotros": "habéis conocido", "ellos": "han conocido"},
+      "future_simple": {"yo": "conoceré", "tú": "conocerás", "vos": "conocerás", "él": "conocerá", "nosotros": "conoceremos", "vosotros": "conoceréis", "ellos": "conocerán"},
+      "condicional_simple": {"yo": "conocería", "tú": "conocerías", "vos": "conocerías", "él": "conocería", "nosotros": "conoceríamos", "vosotros": "conoceríais", "ellos": "conocerían"},
+      "imperfect_indicative": {"yo": "conocía", "tú": "conocías", "vos": "conocías", "él": "conocía", "nosotros": "conocíamos", "vosotros": "conocíais", "ellos": "conocían"}
     },
     "conjugations_en": {
       "present": {"I": "know", "you": "know", "he": "knows", "she": "knows", "it": "knows", "we": "know", "they": "know"},
@@ -683,12 +683,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "leo", "tú": "lees", "él": "lee", "nosotros": "leemos", "vosotros": "leéis", "ellos": "leen"},
-      "past_simple": {"yo": "leí", "tú": "leíste", "él": "leyó", "nosotros": "leímos", "vosotros": "leísteis", "ellos": "leyeron"},
-      "present_perfect": {"yo": "he leído", "tú": "has leído", "él": "ha leído", "nosotros": "hemos leído", "vosotros": "habéis leído", "ellos": "han leído"},
-      "future_simple": {"yo": "leeré", "tú": "leerás", "él": "leerá", "nosotros": "leeremos", "vosotros": "leeréis", "ellos": "leerán"},
-      "condicional_simple": {"yo": "leería", "tú": "leerías", "él": "leería", "nosotros": "leeríamos", "vosotros": "leeríais", "ellos": "leerían"},
-      "imperfect_indicative": {"yo": "leía", "tú": "leías", "él": "leía", "nosotros": "leíamos", "vosotros": "leíais", "ellos": "leían"}
+      "present": {"yo": "leo", "tú": "lees", "vos": "leés", "él": "lee", "nosotros": "leemos", "vosotros": "leéis", "ellos": "leen"},
+      "past_simple": {"yo": "leí", "tú": "leíste", "vos": "leíste", "él": "leyó", "nosotros": "leímos", "vosotros": "leísteis", "ellos": "leyeron"},
+      "present_perfect": {"yo": "he leído", "tú": "has leído", "vos": "has leído", "él": "ha leído", "nosotros": "hemos leído", "vosotros": "habéis leído", "ellos": "han leído"},
+      "future_simple": {"yo": "leeré", "tú": "leerás", "vos": "leerás", "él": "leerá", "nosotros": "leeremos", "vosotros": "leeréis", "ellos": "leerán"},
+      "condicional_simple": {"yo": "leería", "tú": "leerías", "vos": "leerías", "él": "leería", "nosotros": "leeríamos", "vosotros": "leeríais", "ellos": "leerían"},
+      "imperfect_indicative": {"yo": "leía", "tú": "leías", "vos": "leías", "él": "leía", "nosotros": "leíamos", "vosotros": "leíais", "ellos": "leían"}
     },
     "conjugations_en": {
       "present": {"I": "read", "you": "read", "he": "reads", "she": "reads", "it": "reads", "we": "read", "they": "read"},
@@ -711,12 +711,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "pido", "tú": "pides", "él": "pide", "nosotros": "pedimos", "vosotros": "pedís", "ellos": "piden"},
-      "past_simple": {"yo": "pedí", "tú": "pediste", "él": "pidió", "nosotros": "pedimos", "vosotros": "pedisteis", "ellos": "pidieron"},
-      "present_perfect": {"yo": "he pedido", "tú": "has pedido", "él": "ha pedido", "nosotros": "hemos pedido", "vosotros": "habéis pedido", "ellos": "han pedido"},
-      "future_simple": {"yo": "pediré", "tú": "pedirás", "él": "pedirá", "nosotros": "pediremos", "vosotros": "pediréis", "ellos": "pedirán"},
-      "condicional_simple": {"yo": "pediría", "tú": "pedirías", "él": "pediría", "nosotros": "pediríamos", "vosotros": "pediríais", "ellos": "pedirían"},
-      "imperfect_indicative": {"yo": "pedía", "tú": "pedías", "él": "pedía", "nosotros": "pedíamos", "vosotros": "pedíais", "ellos": "pedían"}
+      "present": {"yo": "pido", "tú": "pides", "vos": "pedís", "él": "pide", "nosotros": "pedimos", "vosotros": "pedís", "ellos": "piden"},
+      "past_simple": {"yo": "pedí", "tú": "pediste", "vos": "pediste", "él": "pidió", "nosotros": "pedimos", "vosotros": "pedisteis", "ellos": "pidieron"},
+      "present_perfect": {"yo": "he pedido", "tú": "has pedido", "vos": "has pedido", "él": "ha pedido", "nosotros": "hemos pedido", "vosotros": "habéis pedido", "ellos": "han pedido"},
+      "future_simple": {"yo": "pediré", "tú": "pedirás", "vos": "pedirás", "él": "pedirá", "nosotros": "pediremos", "vosotros": "pediréis", "ellos": "pedirán"},
+      "condicional_simple": {"yo": "pediría", "tú": "pedirías", "vos": "pedirías", "él": "pediría", "nosotros": "pediríamos", "vosotros": "pediríais", "ellos": "pedirían"},
+      "imperfect_indicative": {"yo": "pedía", "tú": "pedías", "vos": "pedías", "él": "pedía", "nosotros": "pedíamos", "vosotros": "pedíais", "ellos": "pedían"}
     },
     "conjugations_en": {
       "present": {"I": "ask for", "you": "ask for", "he": "asks for", "she": "asks for", "it": "asks for", "we": "ask for", "they": "ask for"},
@@ -739,12 +739,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "muero", "tú": "mueres", "él": "muere", "nosotros": "morimos", "vosotros": "morís", "ellos": "mueren"},
-      "past_simple": {"yo": "morí", "tú": "moriste", "él": "murió", "nosotros": "morimos", "vosotros": "moristeis", "ellos": "murieron"},
-      "present_perfect": {"yo": "he muerto", "tú": "has muerto", "él": "ha muerto", "nosotros": "hemos muerto", "vosotros": "habéis muerto", "ellos": "han muerto"},
-      "future_simple": {"yo": "moriré", "tú": "morirás", "él": "morirá", "nosotros": "moriremos", "vosotros": "moriréis", "ellos": "morirán"},
-      "condicional_simple": {"yo": "moriría", "tú": "morirías", "él": "moriría", "nosotros": "moriríamos", "vosotros": "moriríais", "ellos": "morirían"},
-      "imperfect_indicative": {"yo": "moría", "tú": "morías", "él": "moría", "nosotros": "moríamos", "vosotros": "moríais", "ellos": "morían"}
+      "present": {"yo": "muero", "tú": "mueres", "vos": "morís", "él": "muere", "nosotros": "morimos", "vosotros": "morís", "ellos": "mueren"},
+      "past_simple": {"yo": "morí", "tú": "moriste", "vos": "moriste", "él": "murió", "nosotros": "morimos", "vosotros": "moristeis", "ellos": "murieron"},
+      "present_perfect": {"yo": "he muerto", "tú": "has muerto", "vos": "has muerto", "él": "ha muerto", "nosotros": "hemos muerto", "vosotros": "habéis muerto", "ellos": "han muerto"},
+      "future_simple": {"yo": "moriré", "tú": "morirás", "vos": "morirás", "él": "morirá", "nosotros": "moriremos", "vosotros": "moriréis", "ellos": "morirán"},
+      "condicional_simple": {"yo": "moriría", "tú": "morirías", "vos": "morirías", "él": "moriría", "nosotros": "moriríamos", "vosotros": "moriríais", "ellos": "morirían"},
+      "imperfect_indicative": {"yo": "moría", "tú": "morías", "vos": "morías", "él": "moría", "nosotros": "moríamos", "vosotros": "moríais", "ellos": "morían"}
     },
     "conjugations_en": {
       "present": {"I": "die", "you": "die", "he": "dies", "she": "dies", "it": "dies", "we": "die", "they": "die"},
@@ -767,12 +767,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "oigo", "tú": "oyes", "él": "oye", "nosotros": "oímos", "vosotros": "oís", "ellos": "oyen"},
-      "past_simple": {"yo": "oí", "tú": "oíste", "él": "oyó", "nosotros": "oímos", "vosotros": "oísteis", "ellos": "oyeron"},
-      "present_perfect": {"yo": "he oído", "tú": "has oído", "él": "ha oído", "nosotros": "hemos oído", "vosotros": "habéis oído", "ellos": "han oído"},
-      "future_simple": {"yo": "oiré", "tú": "oirás", "él": "oirá", "nosotros": "oiremos", "vosotros": "oiréis", "ellos": "oirán"},
-      "condicional_simple": {"yo": "oiría", "tú": "oirías", "él": "oiría", "nosotros": "oiríamos", "vosotros": "oiríais", "ellos": "oirían"},
-      "imperfect_indicative": {"yo": "oía", "tú": "oías", "él": "oía", "nosotros": "oíamos", "vosotros": "oíais", "ellos": "oían"}
+      "present": {"yo": "oigo", "tú": "oyes", "vos": "oís", "él": "oye", "nosotros": "oímos", "vosotros": "oís", "ellos": "oyen"},
+      "past_simple": {"yo": "oí", "tú": "oíste", "vos": "oíste", "él": "oyó", "nosotros": "oímos", "vosotros": "oísteis", "ellos": "oyeron"},
+      "present_perfect": {"yo": "he oído", "tú": "has oído", "vos": "has oído", "él": "ha oído", "nosotros": "hemos oído", "vosotros": "habéis oído", "ellos": "han oído"},
+      "future_simple": {"yo": "oiré", "tú": "oirás", "vos": "oirás", "él": "oirá", "nosotros": "oiremos", "vosotros": "oiréis", "ellos": "oirán"},
+      "condicional_simple": {"yo": "oiría", "tú": "oirías", "vos": "oirías", "él": "oiría", "nosotros": "oiríamos", "vosotros": "oiríais", "ellos": "oirían"},
+      "imperfect_indicative": {"yo": "oía", "tú": "oías", "vos": "oías", "él": "oía", "nosotros": "oíamos", "vosotros": "oíais", "ellos": "oían"}
     },
     "conjugations_en": {
       "present": {"I": "hear", "you": "hear", "he": "hears", "she": "hears", "it": "hears", "we": "hear", "they": "hear"},
@@ -795,12 +795,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "hago", "tú": "haces", "él": "hace", "nosotros": "hacemos", "vosotros": "hacéis", "ellos": "hacen"},
-      "past_simple": {"yo": "hice", "tú": "hiciste", "él": "hizo", "nosotros": "hicimos", "vosotros": "hicisteis", "ellos": "hicieron"},
-      "present_perfect": {"yo": "he hecho", "tú": "has hecho", "él": "ha hecho", "nosotros": "hemos hecho", "vosotros": "habéis hecho", "ellos": "han hecho"},
-      "future_simple": {"yo": "haré", "tú": "harás", "él": "hará", "nosotros": "haremos", "vosotros": "haréis", "ellos": "harán"},
-      "condicional_simple": {"yo": "haría", "tú": "harías", "él": "haría", "nosotros": "haríamos", "vosotros": "haríais", "ellos": "harían"},
-      "imperfect_indicative": {"yo": "hacía", "tú": "hacías", "él": "hacía", "nosotros": "hacíamos", "vosotros": "hacíais", "ellos": "hacían"}
+      "present": {"yo": "hago", "tú": "haces", "vos": "hacés", "él": "hace", "nosotros": "hacemos", "vosotros": "hacéis", "ellos": "hacen"},
+      "past_simple": {"yo": "hice", "tú": "hiciste", "vos": "hiciste", "él": "hizo", "nosotros": "hicimos", "vosotros": "hicisteis", "ellos": "hicieron"},
+      "present_perfect": {"yo": "he hecho", "tú": "has hecho", "vos": "has hecho", "él": "ha hecho", "nosotros": "hemos hecho", "vosotros": "habéis hecho", "ellos": "han hecho"},
+      "future_simple": {"yo": "haré", "tú": "harás", "vos": "harás", "él": "hará", "nosotros": "haremos", "vosotros": "haréis", "ellos": "harán"},
+      "condicional_simple": {"yo": "haría", "tú": "harías", "vos": "harías", "él": "haría", "nosotros": "haríamos", "vosotros": "haríais", "ellos": "harían"},
+      "imperfect_indicative": {"yo": "hacía", "tú": "hacías", "vos": "hacías", "él": "hacía", "nosotros": "hacíamos", "vosotros": "hacíais", "ellos": "hacían"}
     },
     "conjugations_en": {
       "present": {"I": "do", "you": "do", "he": "does", "she": "does", "it": "does", "we": "do", "they": "do"},
@@ -823,12 +823,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "camino", "tú": "caminas", "él": "camina", "nosotros": "caminamos", "vosotros": "camináis", "ellos": "caminan"},
-      "past_simple": {"yo": "caminé", "tú": "caminaste", "él": "caminó", "nosotros": "caminamos", "vosotros": "caminasteis", "ellos": "caminaron"},
-      "present_perfect": {"yo": "he caminado", "tú": "has caminado", "él": "ha caminado", "nosotros": "hemos caminado", "vosotros": "habéis caminado", "ellos": "han caminado"},
-      "future_simple": {"yo": "caminaré", "tú": "caminarás", "él": "caminará", "nosotros": "caminaremos", "vosotros": "caminaréis", "ellos": "caminarán"},
-      "condicional_simple": {"yo": "caminaría", "tú": "caminarías", "él": "caminaría", "nosotros": "caminaríamos", "vosotros": "caminaríais", "ellos": "caminarían"},
-      "imperfect_indicative": {"yo": "caminaba", "tú": "caminabas", "él": "caminaba", "nosotros": "caminábamos", "vosotros": "caminabais", "ellos": "caminaban"}
+      "present": {"yo": "camino", "tú": "caminas", "vos": "caminás", "él": "camina", "nosotros": "caminamos", "vosotros": "camináis", "ellos": "caminan"},
+      "past_simple": {"yo": "caminé", "tú": "caminaste", "vos": "caminaste", "él": "caminó", "nosotros": "caminamos", "vosotros": "caminasteis", "ellos": "caminaron"},
+      "present_perfect": {"yo": "he caminado", "tú": "has caminado", "vos": "has caminado", "él": "ha caminado", "nosotros": "hemos caminado", "vosotros": "habéis caminado", "ellos": "han caminado"},
+      "future_simple": {"yo": "caminaré", "tú": "caminarás", "vos": "caminarás", "él": "caminará", "nosotros": "caminaremos", "vosotros": "caminaréis", "ellos": "caminarán"},
+      "condicional_simple": {"yo": "caminaría", "tú": "caminarías", "vos": "caminarías", "él": "caminaría", "nosotros": "caminaríamos", "vosotros": "caminaríais", "ellos": "caminarían"},
+      "imperfect_indicative": {"yo": "caminaba", "tú": "caminabas", "vos": "caminabas", "él": "caminaba", "nosotros": "caminábamos", "vosotros": "caminabais", "ellos": "caminaban"}
     },
     "conjugations_en": {
       "present": {"I": "walk", "you": "walk", "he": "walks", "she": "walks", "it": "walks", "we": "walk", "they": "walk"},
@@ -851,12 +851,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "canto", "tú": "cantas", "él": "canta", "nosotros": "cantamos", "vosotros": "cantáis", "ellos": "cantan"},
-      "past_simple": {"yo": "canté", "tú": "cantaste", "él": "cantó", "nosotros": "cantamos", "vosotros": "cantasteis", "ellos": "cantaron"},
-      "present_perfect": {"yo": "he cantado", "tú": "has cantado", "él": "ha cantado", "nosotros": "hemos cantado", "vosotros": "habéis cantado", "ellos": "han cantado"},
-      "future_simple": {"yo": "cantaré", "tú": "cantarás", "él": "cantará", "nosotros": "cantaremos", "vosotros": "cantaréis", "ellos": "cantarán"},
-      "condicional_simple": {"yo": "cantaría", "tú": "cantarías", "él": "cantaría", "nosotros": "cantaríamos", "vosotros": "cantaríais", "ellos": "cantarían"},
-      "imperfect_indicative": {"yo": "cantaba", "tú": "cantabas", "él": "cantaba", "nosotros": "cantábamos", "vosotros": "cantabais", "ellos": "cantaban"}
+      "present": {"yo": "canto", "tú": "cantas", "vos": "cantás", "él": "canta", "nosotros": "cantamos", "vosotros": "cantáis", "ellos": "cantan"},
+      "past_simple": {"yo": "canté", "tú": "cantaste", "vos": "cantaste", "él": "cantó", "nosotros": "cantamos", "vosotros": "cantasteis", "ellos": "cantaron"},
+      "present_perfect": {"yo": "he cantado", "tú": "has cantado", "vos": "has cantado", "él": "ha cantado", "nosotros": "hemos cantado", "vosotros": "habéis cantado", "ellos": "han cantado"},
+      "future_simple": {"yo": "cantaré", "tú": "cantarás", "vos": "cantarás", "él": "cantará", "nosotros": "cantaremos", "vosotros": "cantaréis", "ellos": "cantarán"},
+      "condicional_simple": {"yo": "cantaría", "tú": "cantarías", "vos": "cantarías", "él": "cantaría", "nosotros": "cantaríamos", "vosotros": "cantaríais", "ellos": "cantarían"},
+      "imperfect_indicative": {"yo": "cantaba", "tú": "cantabas", "vos": "cantabas", "él": "cantaba", "nosotros": "cantábamos", "vosotros": "cantabais", "ellos": "cantaban"}
     },
     "conjugations_en": {
       "present": {"I": "sing", "you": "sing", "he": "sings", "she": "sings", "it": "sings", "we": "sing", "they": "sing"},
@@ -879,12 +879,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "bailo", "tú": "bailas", "él": "baila", "nosotros": "bailamos", "vosotros": "bailáis", "ellos": "bailan"},
-      "past_simple": {"yo": "bailé", "tú": "bailaste", "él": "bailó", "nosotros": "bailamos", "vosotros": "bailasteis", "ellos": "bailaron"},
-      "present_perfect": {"yo": "he bailado", "tú": "has bailado", "él": "ha bailado", "nosotros": "hemos bailado", "vosotros": "habéis bailado", "ellos": "han bailado"},
-      "future_simple": {"yo": "bailaré", "tú": "bailarás", "él": "bailará", "nosotros": "bailaremos", "vosotros": "bailaréis", "ellos": "bailarán"},
-      "condicional_simple": {"yo": "bailaría", "tú": "bailarías", "él": "bailaría", "nosotros": "bailaríamos", "vosotros": "bailaríais", "ellos": "bailarían"},
-      "imperfect_indicative": {"yo": "bailaba", "tú": "bailabas", "él": "bailaba", "nosotros": "bailábamos", "vosotros": "bailabais", "ellos": "bailaban"}
+      "present": {"yo": "bailo", "tú": "bailas", "vos": "bailás", "él": "baila", "nosotros": "bailamos", "vosotros": "bailáis", "ellos": "bailan"},
+      "past_simple": {"yo": "bailé", "tú": "bailaste", "vos": "bailaste", "él": "bailó", "nosotros": "bailamos", "vosotros": "bailasteis", "ellos": "bailaron"},
+      "present_perfect": {"yo": "he bailado", "tú": "has bailado", "vos": "has bailado", "él": "ha bailado", "nosotros": "hemos bailado", "vosotros": "habéis bailado", "ellos": "han bailado"},
+      "future_simple": {"yo": "bailaré", "tú": "bailarás", "vos": "bailarás", "él": "bailará", "nosotros": "bailaremos", "vosotros": "bailaréis", "ellos": "bailarán"},
+      "condicional_simple": {"yo": "bailaría", "tú": "bailarías", "vos": "bailarías", "él": "bailaría", "nosotros": "bailaríamos", "vosotros": "bailaríais", "ellos": "bailarían"},
+      "imperfect_indicative": {"yo": "bailaba", "tú": "bailabas", "vos": "bailabas", "él": "bailaba", "nosotros": "bailábamos", "vosotros": "bailabais", "ellos": "bailaban"}
     },
     "conjugations_en": {
       "present": {"I": "dance", "you": "dance", "he": "dances", "she": "dances", "it": "dances", "we": "dance", "they": "dance"},
@@ -907,12 +907,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "visito", "tú": "visitas", "él": "visita", "nosotros": "visitamos", "vosotros": "visitáis", "ellos": "visitan"},
-      "past_simple": {"yo": "visité", "tú": "visitaste", "él": "visitó", "nosotros": "visitamos", "vosotros": "visitasteis", "ellos": "visitaron"},
-      "present_perfect": {"yo": "he visitado", "tú": "has visitado", "él": "ha visitado", "nosotros": "hemos visitado", "vosotros": "habéis visitado", "ellos": "han visitado"},
-      "future_simple": {"yo": "visitaré", "tú": "visitarás", "él": "visitará", "nosotros": "visitaremos", "vosotros": "visitaréis", "ellos": "visitarán"},
-      "condicional_simple": {"yo": "visitaría", "tú": "visitarías", "él": "visitaría", "nosotros": "visitaríamos", "vosotros": "visitaríais", "ellos": "visitarían"},
-      "imperfect_indicative": {"yo": "visitaba", "tú": "visitabas", "él": "visitaba", "nosotros": "visitábamos", "vosotros": "visitabais", "ellos": "visitaban"}
+      "present": {"yo": "visito", "tú": "visitas", "vos": "visitás", "él": "visita", "nosotros": "visitamos", "vosotros": "visitáis", "ellos": "visitan"},
+      "past_simple": {"yo": "visité", "tú": "visitaste", "vos": "visitaste", "él": "visitó", "nosotros": "visitamos", "vosotros": "visitasteis", "ellos": "visitaron"},
+      "present_perfect": {"yo": "he visitado", "tú": "has visitado", "vos": "has visitado", "él": "ha visitado", "nosotros": "hemos visitado", "vosotros": "habéis visitado", "ellos": "han visitado"},
+      "future_simple": {"yo": "visitaré", "tú": "visitarás", "vos": "visitarás", "él": "visitará", "nosotros": "visitaremos", "vosotros": "visitaréis", "ellos": "visitarán"},
+      "condicional_simple": {"yo": "visitaría", "tú": "visitarías", "vos": "visitarías", "él": "visitaría", "nosotros": "visitaríamos", "vosotros": "visitaríais", "ellos": "visitarían"},
+      "imperfect_indicative": {"yo": "visitaba", "tú": "visitabas", "vos": "visitabas", "él": "visitaba", "nosotros": "visitábamos", "vosotros": "visitabais", "ellos": "visitaban"}
     },
     "conjugations_en": {
       "present": {"I": "visit", "you": "visit", "he": "visits", "she": "visits", "it": "visits", "we": "visit", "they": "visit"},
@@ -935,12 +935,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "corro", "tú": "corres", "él": "corre", "nosotros": "corremos", "vosotros": "corréis", "ellos": "corren"},
-      "past_simple": {"yo": "corrí", "tú": "corriste", "él": "corrió", "nosotros": "corrimos", "vosotros": "corristeis", "ellos": "corrieron"},
-      "present_perfect": {"yo": "he corrido", "tú": "has corrido", "él": "ha corrido", "nosotros": "hemos corrido", "vosotros": "habéis corrido", "ellos": "han corrido"},
-      "future_simple": {"yo": "correré", "tú": "correrás", "él": "correrá", "nosotros": "correremos", "vosotros": "correréis", "ellos": "correrán"},
-      "condicional_simple": {"yo": "correría", "tú": "correrías", "él": "correría", "nosotros": "correríamos", "vosotros": "correríais", "ellos": "correrían"},
-      "imperfect_indicative": {"yo": "corría", "tú": "corrías", "él": "corría", "nosotros": "corríamos", "vosotros": "corríais", "ellos": "corrían"}
+      "present": {"yo": "corro", "tú": "corres", "vos": "corrés", "él": "corre", "nosotros": "corremos", "vosotros": "corréis", "ellos": "corren"},
+      "past_simple": {"yo": "corrí", "tú": "corriste", "vos": "corriste", "él": "corrió", "nosotros": "corrimos", "vosotros": "corristeis", "ellos": "corrieron"},
+      "present_perfect": {"yo": "he corrido", "tú": "has corrido", "vos": "has corrido", "él": "ha corrido", "nosotros": "hemos corrido", "vosotros": "habéis corrido", "ellos": "han corrido"},
+      "future_simple": {"yo": "correré", "tú": "correrás", "vos": "correrás", "él": "correrá", "nosotros": "correremos", "vosotros": "correréis", "ellos": "correrán"},
+      "condicional_simple": {"yo": "correría", "tú": "correrías", "vos": "correrías", "él": "correría", "nosotros": "correríamos", "vosotros": "correríais", "ellos": "correrían"},
+      "imperfect_indicative": {"yo": "corría", "tú": "corrías", "vos": "corrías", "él": "corría", "nosotros": "corríamos", "vosotros": "corríais", "ellos": "corrían"}
     },
     "conjugations_en": {
       "present": {"I": "run", "you": "run", "he": "runs", "she": "runs", "it": "runs", "we": "run", "they": "run"},
@@ -963,12 +963,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "compro", "tú": "compras", "él": "compra", "nosotros": "compramos", "vosotros": "compráis", "ellos": "compran"},
-      "past_simple": {"yo": "compré", "tú": "compraste", "él": "compró", "nosotros": "compramos", "vosotros": "comprasteis", "ellos": "compraron"},
-      "present_perfect": {"yo": "he comprado", "tú": "has comprado", "él": "ha comprado", "nosotros": "hemos comprado", "vosotros": "habéis comprado", "ellos": "han comprado"},
-      "future_simple": {"yo": "compraré", "tú": "comprarás", "él": "comprará", "nosotros": "compraremos", "vosotros": "compraréis", "ellos": "comprarán"},
-      "condicional_simple": {"yo": "compraría", "tú": "comprarías", "él": "compraría", "nosotros": "compraríamos", "vosotros": "compraríais", "ellos": "comprarían"},
-      "imperfect_indicative": {"yo": "compraba", "tú": "comprabas", "él": "compraba", "nosotros": "comprábamos", "vosotros": "comprabais", "ellos": "compraban"}
+      "present": {"yo": "compro", "tú": "compras", "vos": "comprás", "él": "compra", "nosotros": "compramos", "vosotros": "compráis", "ellos": "compran"},
+      "past_simple": {"yo": "compré", "tú": "compraste", "vos": "compraste", "él": "compró", "nosotros": "compramos", "vosotros": "comprasteis", "ellos": "compraron"},
+      "present_perfect": {"yo": "he comprado", "tú": "has comprado", "vos": "has comprado", "él": "ha comprado", "nosotros": "hemos comprado", "vosotros": "habéis comprado", "ellos": "han comprado"},
+      "future_simple": {"yo": "compraré", "tú": "comprarás", "vos": "comprarás", "él": "comprará", "nosotros": "compraremos", "vosotros": "compraréis", "ellos": "comprarán"},
+      "condicional_simple": {"yo": "compraría", "tú": "comprarías", "vos": "comprarías", "él": "compraría", "nosotros": "compraríamos", "vosotros": "compraríais", "ellos": "comprarían"},
+      "imperfect_indicative": {"yo": "compraba", "tú": "comprabas", "vos": "comprabas", "él": "compraba", "nosotros": "comprábamos", "vosotros": "comprabais", "ellos": "compraban"}
     },
     "conjugations_en": {
       "present": {"I": "buy", "you": "buy", "he": "buys", "she": "buys", "it": "buys", "we": "buy", "they": "buy"},
@@ -991,12 +991,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "nado", "tú": "nadas", "él": "nada", "nosotros": "nadamos", "vosotros": "nadáis", "ellos": "nadan"},
-      "past_simple": {"yo": "nadé", "tú": "nadaste", "él": "nadó", "nosotros": "nadamos", "vosotros": "nadasteis", "ellos": "nadaron"},
-      "present_perfect": {"yo": "he nadado", "tú": "has nadado", "él": "ha nadado", "nosotros": "hemos nadado", "vosotros": "habéis nadado", "ellos": "han nadado"},
-      "future_simple": {"yo": "nadaré", "tú": "nadarás", "él": "nadará", "nosotros": "nadaremos", "vosotros": "nadaréis", "ellos": "nadarán"},
-      "condicional_simple": {"yo": "nadaría", "tú": "nadarías", "él": "nadaría", "nosotros": "nadaríamos", "vosotros": "nadaríais", "ellos": "nadarían"},
-      "imperfect_indicative": {"yo": "nadaba", "tú": "nadabas", "él": "nadaba", "nosotros": "nadábamos", "vosotros": "nadabais", "ellos": "nadaban"}
+      "present": {"yo": "nado", "tú": "nadas", "vos": "nadás", "él": "nada", "nosotros": "nadamos", "vosotros": "nadáis", "ellos": "nadan"},
+      "past_simple": {"yo": "nadé", "tú": "nadaste", "vos": "nadaste", "él": "nadó", "nosotros": "nadamos", "vosotros": "nadasteis", "ellos": "nadaron"},
+      "present_perfect": {"yo": "he nadado", "tú": "has nadado", "vos": "has nadado", "él": "ha nadado", "nosotros": "hemos nadado", "vosotros": "habéis nadado", "ellos": "han nadado"},
+      "future_simple": {"yo": "nadaré", "tú": "nadarás", "vos": "nadarás", "él": "nadará", "nosotros": "nadaremos", "vosotros": "nadaréis", "ellos": "nadarán"},
+      "condicional_simple": {"yo": "nadaría", "tú": "nadarías", "vos": "nadarías", "él": "nadaría", "nosotros": "nadaríamos", "vosotros": "nadaríais", "ellos": "nadarían"},
+      "imperfect_indicative": {"yo": "nadaba", "tú": "nadabas", "vos": "nadabas", "él": "nadaba", "nosotros": "nadábamos", "vosotros": "nadabais", "ellos": "nadaban"}
     },
     "conjugations_en": {
       "present": {"I": "swim", "you": "swim", "he": "swims", "she": "swims", "it": "swims", "we": "swim", "they": "swim"},
@@ -1019,12 +1019,12 @@
       "imperfect_indicative": ["irregular_imperfect"]
     },
     "conjugations": {
-      "present": {"yo": "veo", "tú": "ves", "él": "ve", "nosotros": "vemos", "vosotros": "veis", "ellos": "ven"},
-      "past_simple": {"yo": "vi", "tú": "viste", "él": "vio", "nosotros": "vimos", "vosotros": "visteis", "ellos": "vieron"},
-      "present_perfect": {"yo": "he visto", "tú": "has visto", "él": "ha visto", "nosotros": "hemos visto", "vosotros": "habéis visto", "ellos": "han visto"},
-      "future_simple": {"yo": "veré", "tú": "verás", "él": "verá", "nosotros": "veremos", "vosotros": "veréis", "ellos": "verán"},
-      "condicional_simple": {"yo": "vería", "tú": "verías", "él": "vería", "nosotros": "veríamos", "vosotros": "veríais", "ellos": "verían"},
-      "imperfect_indicative": {"yo": "veía", "tú": "veías", "él": "veía", "nosotros": "veíamos", "vosotros": "veíais", "ellos": "veían"}
+      "present": {"yo": "veo", "tú": "ves", "vos": "ves", "él": "ve", "nosotros": "vemos", "vosotros": "veis", "ellos": "ven"},
+      "past_simple": {"yo": "vi", "tú": "viste", "vos": "viste", "él": "vio", "nosotros": "vimos", "vosotros": "visteis", "ellos": "vieron"},
+      "present_perfect": {"yo": "he visto", "tú": "has visto", "vos": "has visto", "él": "ha visto", "nosotros": "hemos visto", "vosotros": "habéis visto", "ellos": "han visto"},
+      "future_simple": {"yo": "veré", "tú": "verás", "vos": "verás", "él": "verá", "nosotros": "veremos", "vosotros": "veréis", "ellos": "verán"},
+      "condicional_simple": {"yo": "vería", "tú": "verías", "vos": "verías", "él": "vería", "nosotros": "veríamos", "vosotros": "veríais", "ellos": "verían"},
+      "imperfect_indicative": {"yo": "veía", "tú": "veías", "vos": "veías", "él": "veía", "nosotros": "veíamos", "vosotros": "veíais", "ellos": "veían"}
     },
     "conjugations_en": {
       "present": {"I": "see", "you": "see", "he": "sees", "she": "sees", "it": "sees", "we": "see", "they": "see"},
@@ -1047,12 +1047,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "parezco", "tú": "pareces", "él": "parece", "nosotros": "parecemos", "vosotros": "parecéis", "ellos": "parecen"},
-      "past_simple": {"yo": "parecí", "tú": "pareciste", "él": "pareció", "nosotros": "parecimos", "vosotros": "parecisteis", "ellos": "parecieron"},
-      "present_perfect": {"yo": "he parecido", "tú": "has parecido", "él": "ha parecido", "nosotros": "hemos parecido", "vosotros": "habéis parecido", "ellos": "han parecido"},
-      "future_simple": {"yo": "pareceré", "tú": "parecerás", "él": "parecerá", "nosotros": "pareceremos", "vosotros": "pareceréis", "ellos": "parecerán"},
-      "condicional_simple": {"yo": "parecería", "tú": "parecerías", "él": "parecería", "nosotros": "pareceríamos", "vosotros": "pareceríais", "ellos": "parecerían"},
-      "imperfect_indicative": {"yo": "parecía", "tú": "parecías", "él": "parecía", "nosotros": "parecíamos", "vosotros": "parecíais", "ellos": "parecían"}
+      "present": {"yo": "parezco", "tú": "pareces", "vos": "parecés", "él": "parece", "nosotros": "parecemos", "vosotros": "parecéis", "ellos": "parecen"},
+      "past_simple": {"yo": "parecí", "tú": "pareciste", "vos": "pareciste", "él": "pareció", "nosotros": "parecimos", "vosotros": "parecisteis", "ellos": "parecieron"},
+      "present_perfect": {"yo": "he parecido", "tú": "has parecido", "vos": "has parecido", "él": "ha parecido", "nosotros": "hemos parecido", "vosotros": "habéis parecido", "ellos": "han parecido"},
+      "future_simple": {"yo": "pareceré", "tú": "parecerás", "vos": "parecerás", "él": "parecerá", "nosotros": "pareceremos", "vosotros": "pareceréis", "ellos": "parecerán"},
+      "condicional_simple": {"yo": "parecería", "tú": "parecerías", "vos": "parecerías", "él": "parecería", "nosotros": "pareceríamos", "vosotros": "pareceríais", "ellos": "parecerían"},
+      "imperfect_indicative": {"yo": "parecía", "tú": "parecías", "vos": "parecías", "él": "parecía", "nosotros": "parecíamos", "vosotros": "parecíais", "ellos": "parecían"}
     },
     "conjugations_en": {
       "present": {"I": "seem", "you": "seem", "he": "seems", "she": "seems", "it": "seems", "we": "seem", "they": "seem"},
@@ -1075,12 +1075,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "creo", "tú": "crees", "él": "cree", "nosotros": "creemos", "vosotros": "creéis", "ellos": "creen"},
-      "past_simple": {"yo": "creí", "tú": "creíste", "él": "creyó", "nosotros": "creímos", "vosotros": "creísteis", "ellos": "creyeron"},
-      "present_perfect": {"yo": "he creído", "tú": "has creído", "él": "ha creído", "nosotros": "hemos creído", "vosotros": "habéis creído", "ellos": "han creído"},
-      "future_simple": {"yo": "creeré", "tú": "creerás", "él": "creerá", "nosotros": "creeremos", "vosotros": "creeréis", "ellos": "creerán"},
-      "condicional_simple": {"yo": "creería", "tú": "creerías", "él": "creería", "nosotros": "creeríamos", "vosotros": "creeríais", "ellos": "creerían"},
-      "imperfect_indicative": {"yo": "creía", "tú": "creías", "él": "creía", "nosotros": "creíamos", "vosotros": "creíais", "ellos": "creían"}
+      "present": {"yo": "creo", "tú": "crees", "vos": "creés", "él": "cree", "nosotros": "creemos", "vosotros": "creéis", "ellos": "creen"},
+      "past_simple": {"yo": "creí", "tú": "creíste", "vos": "creíste", "él": "creyó", "nosotros": "creímos", "vosotros": "creísteis", "ellos": "creyeron"},
+      "present_perfect": {"yo": "he creído", "tú": "has creído", "vos": "has creído", "él": "ha creído", "nosotros": "hemos creído", "vosotros": "habéis creído", "ellos": "han creído"},
+      "future_simple": {"yo": "creeré", "tú": "creerás", "vos": "creerás", "él": "creerá", "nosotros": "creeremos", "vosotros": "creeréis", "ellos": "creerán"},
+      "condicional_simple": {"yo": "creería", "tú": "creerías", "vos": "creerías", "él": "creería", "nosotros": "creeríamos", "vosotros": "creeríais", "ellos": "creerían"},
+      "imperfect_indicative": {"yo": "creía", "tú": "creías", "vos": "creías", "él": "creía", "nosotros": "creíamos", "vosotros": "creíais", "ellos": "creían"}
     },
     "conjugations_en": {
       "present": {"I": "believe", "you": "believe", "he": "believes", "she": "believes", "it": "believes", "we": "believe", "they": "believe"},
@@ -1103,12 +1103,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "llevo", "tú": "llevas", "él": "lleva", "nosotros": "llevamos", "vosotros": "lleváis", "ellos": "llevan"},
-      "past_simple": {"yo": "llevé", "tú": "llevaste", "él": "llevó", "nosotros": "llevamos", "vosotros": "llevasteis", "ellos": "llevaron"},
-      "present_perfect": {"yo": "he llevado", "tú": "has llevado", "él": "ha llevado", "nosotros": "hemos llevado", "vosotros": "habéis llevado", "ellos": "han llevado"},
-      "future_simple": {"yo": "llevaré", "tú": "llevarás", "él": "llevará", "nosotros": "llevaremos", "vosotros": "llevaréis", "ellos": "llevarán"},
-      "condicional_simple": {"yo": "llevaría", "tú": "llevarías", "él": "llevaría", "nosotros": "llevaríamos", "vosotros": "llevaríais", "ellos": "llevarían"},
-      "imperfect_indicative": {"yo": "llevaba", "tú": "llevabas", "él": "llevaba", "nosotros": "llevábamos", "vosotros": "llevabais", "ellos": "llevaban"}
+      "present": {"yo": "llevo", "tú": "llevas", "vos": "llevás", "él": "lleva", "nosotros": "llevamos", "vosotros": "lleváis", "ellos": "llevan"},
+      "past_simple": {"yo": "llevé", "tú": "llevaste", "vos": "llevaste", "él": "llevó", "nosotros": "llevamos", "vosotros": "llevasteis", "ellos": "llevaron"},
+      "present_perfect": {"yo": "he llevado", "tú": "has llevado", "vos": "has llevado", "él": "ha llevado", "nosotros": "hemos llevado", "vosotros": "habéis llevado", "ellos": "han llevado"},
+      "future_simple": {"yo": "llevaré", "tú": "llevarás", "vos": "llevarás", "él": "llevará", "nosotros": "llevaremos", "vosotros": "llevaréis", "ellos": "llevarán"},
+      "condicional_simple": {"yo": "llevaría", "tú": "llevarías", "vos": "llevarías", "él": "llevaría", "nosotros": "llevaríamos", "vosotros": "llevaríais", "ellos": "llevarían"},
+      "imperfect_indicative": {"yo": "llevaba", "tú": "llevabas", "vos": "llevabas", "él": "llevaba", "nosotros": "llevábamos", "vosotros": "llevabais", "ellos": "llevaban"}
     },
     "conjugations_en": {
       "present": {"I": "carry", "you": "carry", "he": "carries", "she": "carries", "it": "carries", "we": "carry", "they": "carry"},
@@ -1131,12 +1131,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "dejo", "tú": "dejas", "él": "deja", "nosotros": "dejamos", "vosotros": "dejáis", "ellos": "dejan"},
-      "past_simple": {"yo": "dejé", "tú": "dejaste", "él": "dejó", "nosotros": "dejamos", "vosotros": "dejasteis", "ellos": "dejaron"},
-      "present_perfect": {"yo": "he dejado", "tú": "has dejado", "él": "ha dejado", "nosotros": "hemos dejado", "vosotros": "habéis dejado", "ellos": "han dejado"},
-      "future_simple": {"yo": "dejaré", "tú": "dejarás", "él": "dejará", "nosotros": "dejaremos", "vosotros": "dejaréis", "ellos": "dejarán"},
-      "condicional_simple": {"yo": "dejaría", "tú": "dejarías", "él": "dejaría", "nosotros": "dejaríamos", "vosotros": "dejaríais", "ellos": "dejarían"},
-      "imperfect_indicative": {"yo": "dejaba", "tú": "dejabas", "él": "dejaba", "nosotros": "dejábamos", "vosotros": "dejabais", "ellos": "dejaban"}
+      "present": {"yo": "dejo", "tú": "dejas", "vos": "dejás", "él": "deja", "nosotros": "dejamos", "vosotros": "dejáis", "ellos": "dejan"},
+      "past_simple": {"yo": "dejé", "tú": "dejaste", "vos": "dejaste", "él": "dejó", "nosotros": "dejamos", "vosotros": "dejasteis", "ellos": "dejaron"},
+      "present_perfect": {"yo": "he dejado", "tú": "has dejado", "vos": "has dejado", "él": "ha dejado", "nosotros": "hemos dejado", "vosotros": "habéis dejado", "ellos": "han dejado"},
+      "future_simple": {"yo": "dejaré", "tú": "dejarás", "vos": "dejarás", "él": "dejará", "nosotros": "dejaremos", "vosotros": "dejaréis", "ellos": "dejarán"},
+      "condicional_simple": {"yo": "dejaría", "tú": "dejarías", "vos": "dejarías", "él": "dejaría", "nosotros": "dejaríamos", "vosotros": "dejaríais", "ellos": "dejarían"},
+      "imperfect_indicative": {"yo": "dejaba", "tú": "dejabas", "vos": "dejabas", "él": "dejaba", "nosotros": "dejábamos", "vosotros": "dejabais", "ellos": "dejaban"}
     },
     "conjugations_en": {
       "present": {"I": "leave", "you": "leave", "he": "leaves", "she": "leaves", "it": "leaves", "we": "leave", "they": "leave"},
@@ -1159,12 +1159,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "encuentro", "tú": "encuentras", "él": "encuentra", "nosotros": "encontramos", "vosotros": "encontráis", "ellos": "encuentran"},
-      "past_simple": {"yo": "encontré", "tú": "encontraste", "él": "encontró", "nosotros": "encontramos", "vosotros": "encontrasteis", "ellos": "encontraron"},
-      "present_perfect": {"yo": "he encontrado", "tú": "has encontrado", "él": "ha encontrado", "nosotros": "hemos encontrado", "vosotros": "habéis encontrado", "ellos": "han encontrado"},
-      "future_simple": {"yo": "encontraré", "tú": "encontrarás", "él": "encontrará", "nosotros": "encontraremos", "vosotros": "encontraréis", "ellos": "encontrarán"},
-      "condicional_simple": {"yo": "encontraría", "tú": "encontrarías", "él": "encontraría", "nosotros": "encontraríamos", "vosotros": "encontraríais", "ellos": "encontrarían"},
-      "imperfect_indicative": {"yo": "encontraba", "tú": "encontrabas", "él": "encontraba", "nosotros": "encontrábamos", "vosotros": "encontrabais", "ellos": "encontraban"}
+      "present": {"yo": "encuentro", "tú": "encuentras", "vos": "encontrás", "él": "encuentra", "nosotros": "encontramos", "vosotros": "encontráis", "ellos": "encuentran"},
+      "past_simple": {"yo": "encontré", "tú": "encontraste", "vos": "encontraste", "él": "encontró", "nosotros": "encontramos", "vosotros": "encontrasteis", "ellos": "encontraron"},
+      "present_perfect": {"yo": "he encontrado", "tú": "has encontrado", "vos": "has encontrado", "él": "ha encontrado", "nosotros": "hemos encontrado", "vosotros": "habéis encontrado", "ellos": "han encontrado"},
+      "future_simple": {"yo": "encontraré", "tú": "encontrarás", "vos": "encontrarás", "él": "encontrará", "nosotros": "encontraremos", "vosotros": "encontraréis", "ellos": "encontrarán"},
+      "condicional_simple": {"yo": "encontraría", "tú": "encontrarías", "vos": "encontrarías", "él": "encontraría", "nosotros": "encontraríamos", "vosotros": "encontraríais", "ellos": "encontrarían"},
+      "imperfect_indicative": {"yo": "encontraba", "tú": "encontrabas", "vos": "encontrabas", "él": "encontraba", "nosotros": "encontrábamos", "vosotros": "encontrabais", "ellos": "encontraban"}
     },
     "conjugations_en": {
       "present": {"I": "find", "you": "find", "he": "finds", "she": "finds", "it": "finds", "we": "find", "they": "find"},
@@ -1187,12 +1187,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "empiezo", "tú": "empiezas", "él": "empieza", "nosotros": "empezamos", "vosotros": "empezáis", "ellos": "empiezan"},
-      "past_simple": {"yo": "empecé", "tú": "empezaste", "él": "empezó", "nosotros": "empezamos", "vosotros": "empezasteis", "ellos": "empezaron"},
-      "present_perfect": {"yo": "he empezado", "tú": "has empezado", "él": "ha empezado", "nosotros": "hemos empezado", "vosotros": "habéis empezado", "ellos": "han empezado"},
-      "future_simple": {"yo": "empezaré", "tú": "empezarás", "él": "empezará", "nosotros": "empezaremos", "vosotros": "empezaréis", "ellos": "empezarán"},
-      "condicional_simple": {"yo": "empezaría", "tú": "empezarías", "él": "empezaría", "nosotros": "empezaríamos", "vosotros": "empezaríais", "ellos": "empezarían"},
-      "imperfect_indicative": {"yo": "empezaba", "tú": "empezabas", "él": "empezaba", "nosotros": "empezábamos", "vosotros": "empezabais", "ellos": "empezaban"}
+      "present": {"yo": "empiezo", "tú": "empiezas", "vos": "empezás", "él": "empieza", "nosotros": "empezamos", "vosotros": "empezáis", "ellos": "empiezan"},
+      "past_simple": {"yo": "empecé", "tú": "empezaste", "vos": "empezaste", "él": "empezó", "nosotros": "empezamos", "vosotros": "empezasteis", "ellos": "empezaron"},
+      "present_perfect": {"yo": "he empezado", "tú": "has empezado", "vos": "has empezado", "él": "ha empezado", "nosotros": "hemos empezado", "vosotros": "habéis empezado", "ellos": "han empezado"},
+      "future_simple": {"yo": "empezaré", "tú": "empezarás", "vos": "empezarás", "él": "empezará", "nosotros": "empezaremos", "vosotros": "empezaréis", "ellos": "empezarán"},
+      "condicional_simple": {"yo": "empezaría", "tú": "empezarías", "vos": "empezarías", "él": "empezaría", "nosotros": "empezaríamos", "vosotros": "empezaríais", "ellos": "empezarían"},
+      "imperfect_indicative": {"yo": "empezaba", "tú": "empezabas", "vos": "empezabas", "él": "empezaba", "nosotros": "empezábamos", "vosotros": "empezabais", "ellos": "empezaban"}
     },
     "conjugations_en": {
       "present": {"I": "begin", "you": "begin", "he": "begins", "she": "begins", "it": "begins", "we": "begin", "they": "begin"},
@@ -1215,12 +1215,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "espero", "tú": "esperas", "él": "espera", "nosotros": "esperamos", "vosotros": "esperáis", "ellos": "esperan"},
-      "past_simple": {"yo": "esperé", "tú": "esperaste", "él": "esperó", "nosotros": "esperamos", "vosotros": "esperasteis", "ellos": "esperaron"},
-      "present_perfect": {"yo": "he esperado", "tú": "has esperado", "él": "ha esperado", "nosotros": "hemos esperado", "vosotros": "habéis esperado", "ellos": "han esperado"},
-      "future_simple": {"yo": "esperaré", "tú": "esperarás", "él": "esperará", "nosotros": "esperaremos", "vosotros": "esperaréis", "ellos": "esperarán"},
-      "condicional_simple": {"yo": "esperaría", "tú": "esperarías", "él": "esperaría", "nosotros": "esperaríamos", "vosotros": "esperaríais", "ellos": "esperarían"},
-      "imperfect_indicative": {"yo": "esperaba", "tú": "esperabas", "él": "esperaba", "nosotros": "esperábamos", "vosotros": "esperabais", "ellos": "esperaban"}
+      "present": {"yo": "espero", "tú": "esperas", "vos": "esperás", "él": "espera", "nosotros": "esperamos", "vosotros": "esperáis", "ellos": "esperan"},
+      "past_simple": {"yo": "esperé", "tú": "esperaste", "vos": "esperaste", "él": "esperó", "nosotros": "esperamos", "vosotros": "esperasteis", "ellos": "esperaron"},
+      "present_perfect": {"yo": "he esperado", "tú": "has esperado", "vos": "has esperado", "él": "ha esperado", "nosotros": "hemos esperado", "vosotros": "habéis esperado", "ellos": "han esperado"},
+      "future_simple": {"yo": "esperaré", "tú": "esperarás", "vos": "esperarás", "él": "esperará", "nosotros": "esperaremos", "vosotros": "esperaréis", "ellos": "esperarán"},
+      "condicional_simple": {"yo": "esperaría", "tú": "esperarías", "vos": "esperarías", "él": "esperaría", "nosotros": "esperaríamos", "vosotros": "esperaríais", "ellos": "esperarían"},
+      "imperfect_indicative": {"yo": "esperaba", "tú": "esperabas", "vos": "esperabas", "él": "esperaba", "nosotros": "esperábamos", "vosotros": "esperabais", "ellos": "esperaban"}
     },
     "conjugations_en": {
       "present": {"I": "wait", "you": "wait", "he": "waits", "she": "waits", "it": "waits", "we": "wait", "they": "wait"},
@@ -1243,12 +1243,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "necesito", "tú": "necesitas", "él": "necesita", "nosotros": "necesitamos", "vosotros": "necesitáis", "ellos": "necesitan"},
-      "past_simple": {"yo": "necesité", "tú": "necesitaste", "él": "necesitó", "nosotros": "necesitamos", "vosotros": "necesitasteis", "ellos": "necesitaron"},
-      "present_perfect": {"yo": "he necesitado", "tú": "has necesitado", "él": "ha necesitado", "nosotros": "hemos necesitado", "vosotros": "habéis necesitado", "ellos": "han necesitado"},
-      "future_simple": {"yo": "necesitaré", "tú": "necesitarás", "él": "necesitará", "nosotros": "necesitaremos", "vosotros": "necesitaréis", "ellos": "necesitarán"},
-      "condicional_simple": {"yo": "necesitaría", "tú": "necesitarías", "él": "necesitaría", "nosotros": "necesitaríamos", "vosotros": "necesitaríais", "ellos": "necesitarían"},
-      "imperfect_indicative": {"yo": "necesitaba", "tú": "necesitabas", "él": "necesitaba", "nosotros": "necesitábamos", "vosotros": "necesitabais", "ellos": "necesitaban"}
+      "present": {"yo": "necesito", "tú": "necesitas", "vos": "necesitás", "él": "necesita", "nosotros": "necesitamos", "vosotros": "necesitáis", "ellos": "necesitan"},
+      "past_simple": {"yo": "necesité", "tú": "necesitaste", "vos": "necesitaste", "él": "necesitó", "nosotros": "necesitamos", "vosotros": "necesitasteis", "ellos": "necesitaron"},
+      "present_perfect": {"yo": "he necesitado", "tú": "has necesitado", "vos": "has necesitado", "él": "ha necesitado", "nosotros": "hemos necesitado", "vosotros": "habéis necesitado", "ellos": "han necesitado"},
+      "future_simple": {"yo": "necesitaré", "tú": "necesitarás", "vos": "necesitarás", "él": "necesitará", "nosotros": "necesitaremos", "vosotros": "necesitaréis", "ellos": "necesitarán"},
+      "condicional_simple": {"yo": "necesitaría", "tú": "necesitarías", "vos": "necesitarías", "él": "necesitaría", "nosotros": "necesitaríamos", "vosotros": "necesitaríais", "ellos": "necesitarían"},
+      "imperfect_indicative": {"yo": "necesitaba", "tú": "necesitabas", "vos": "necesitabas", "él": "necesitaba", "nosotros": "necesitábamos", "vosotros": "necesitabais", "ellos": "necesitaban"}
     },
     "conjugations_en": {
       "present": {"I": "need", "you": "need", "he": "needs", "she": "needs", "it": "needs", "we": "need", "they": "need"},
@@ -1271,12 +1271,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "uso", "tú": "usas", "él": "usa", "nosotros": "usamos", "vosotros": "usáis", "ellos": "usan"},
-      "past_simple": {"yo": "usé", "tú": "usaste", "él": "usó", "nosotros": "usamos", "vosotros": "usasteis", "ellos": "usaron"},
-      "present_perfect": {"yo": "he usado", "tú": "has usado", "él": "ha usado", "nosotros": "hemos usado", "vosotros": "habéis usado", "ellos": "han usado"},
-      "future_simple": {"yo": "usaré", "tú": "usarás", "él": "usará", "nosotros": "usaremos", "vosotros": "usaréis", "ellos": "usarán"},
-      "condicional_simple": {"yo": "usaría", "tú": "usarías", "él": "usaría", "nosotros": "usaríamos", "vosotros": "usaríais", "ellos": "usarían"},
-      "imperfect_indicative": {"yo": "usaba", "tú": "usabas", "él": "usaba", "nosotros": "usábamos", "vosotros": "usabais", "ellos": "usaban"}
+      "present": {"yo": "uso", "tú": "usas", "vos": "usás", "él": "usa", "nosotros": "usamos", "vosotros": "usáis", "ellos": "usan"},
+      "past_simple": {"yo": "usé", "tú": "usaste", "vos": "usaste", "él": "usó", "nosotros": "usamos", "vosotros": "usasteis", "ellos": "usaron"},
+      "present_perfect": {"yo": "he usado", "tú": "has usado", "vos": "has usado", "él": "ha usado", "nosotros": "hemos usado", "vosotros": "habéis usado", "ellos": "han usado"},
+      "future_simple": {"yo": "usaré", "tú": "usarás", "vos": "usarás", "él": "usará", "nosotros": "usaremos", "vosotros": "usaréis", "ellos": "usarán"},
+      "condicional_simple": {"yo": "usaría", "tú": "usarías", "vos": "usarías", "él": "usaría", "nosotros": "usaríamos", "vosotros": "usaríais", "ellos": "usarían"},
+      "imperfect_indicative": {"yo": "usaba", "tú": "usabas", "vos": "usabas", "él": "usaba", "nosotros": "usábamos", "vosotros": "usabais", "ellos": "usaban"}
     },
     "conjugations_en": {
       "present": {"I": "use", "you": "use", "he": "uses", "she": "uses", "it": "uses", "we": "use", "they": "use"},
@@ -1299,12 +1299,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "recibo", "tú": "recibes", "él": "recibe", "nosotros": "recibimos", "vosotros": "recibís", "ellos": "reciben"},
-      "past_simple": {"yo": "recibí", "tú": "recibiste", "él": "recibió", "nosotros": "recibimos", "vosotros": "recibisteis", "ellos": "recibieron"},
-      "present_perfect": {"yo": "he recibido", "tú": "has recibido", "él": "ha recibido", "nosotros": "hemos recibido", "vosotros": "habéis recibido", "ellos": "han recibido"},
-      "future_simple": {"yo": "recibiré", "tú": "recibirás", "él": "recibirá", "nosotros": "recibiremos", "vosotros": "recibiréis", "ellos": "recibirán"},
-      "condicional_simple": {"yo": "recibiría", "tú": "recibirías", "él": "recibiría", "nosotros": "recibiríamos", "vosotros": "recibiríais", "ellos": "recibirían"},
-      "imperfect_indicative": {"yo": "recibía", "tú": "recibías", "él": "recibía", "nosotros": "recibíamos", "vosotros": "recibíais", "ellos": "recibían"}
+      "present": {"yo": "recibo", "tú": "recibes", "vos": "recibís", "él": "recibe", "nosotros": "recibimos", "vosotros": "recibís", "ellos": "reciben"},
+      "past_simple": {"yo": "recibí", "tú": "recibiste", "vos": "recibiste", "él": "recibió", "nosotros": "recibimos", "vosotros": "recibisteis", "ellos": "recibieron"},
+      "present_perfect": {"yo": "he recibido", "tú": "has recibido", "vos": "has recibido", "él": "ha recibido", "nosotros": "hemos recibido", "vosotros": "habéis recibido", "ellos": "han recibido"},
+      "future_simple": {"yo": "recibiré", "tú": "recibirás", "vos": "recibirás", "él": "recibirá", "nosotros": "recibiremos", "vosotros": "recibiréis", "ellos": "recibirán"},
+      "condicional_simple": {"yo": "recibiría", "tú": "recibirías", "vos": "recibirías", "él": "recibiría", "nosotros": "recibiríamos", "vosotros": "recibiríais", "ellos": "recibirían"},
+      "imperfect_indicative": {"yo": "recibía", "tú": "recibías", "vos": "recibías", "él": "recibía", "nosotros": "recibíamos", "vosotros": "recibíais", "ellos": "recibían"}
     },
     "conjugations_en": {
       "present": {"I": "receive", "you": "receive", "he": "receives", "she": "receives", "it": "receives", "we": "receive", "they": "receive"},
@@ -1327,12 +1327,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "recuerdo", "tú": "recuerdas", "él": "recuerda", "nosotros": "recordamos", "vosotros": "recordáis", "ellos": "recuerdan"},
-      "past_simple": {"yo": "recordé", "tú": "recordaste", "él": "recordó", "nosotros": "recordamos", "vosotros": "recordasteis", "ellos": "recordaron"},
-      "present_perfect": {"yo": "he recordado", "tú": "has recordado", "él": "ha recordado", "nosotros": "hemos recordado", "vosotros": "habéis recordado", "ellos": "han recordado"},
-      "future_simple": {"yo": "recordaré", "tú": "recordarás", "él": "recordará", "nosotros": "recordaremos", "vosotros": "recordaréis", "ellos": "recordarán"},
-      "condicional_simple": {"yo": "recordaría", "tú": "recordarías", "él": "recordaría", "nosotros": "recordaríamos", "vosotros": "recordaríais", "ellos": "recordarían"},
-      "imperfect_indicative": {"yo": "recordaba", "tú": "recordabas", "él": "recordaba", "nosotros": "recordábamos", "vosotros": "recordabais", "ellos": "recordaban"}
+      "present": {"yo": "recuerdo", "tú": "recuerdas", "vos": "recordás", "él": "recuerda", "nosotros": "recordamos", "vosotros": "recordáis", "ellos": "recuerdan"},
+      "past_simple": {"yo": "recordé", "tú": "recordaste", "vos": "recordaste", "él": "recordó", "nosotros": "recordamos", "vosotros": "recordasteis", "ellos": "recordaron"},
+      "present_perfect": {"yo": "he recordado", "tú": "has recordado", "vos": "has recordado", "él": "ha recordado", "nosotros": "hemos recordado", "vosotros": "habéis recordado", "ellos": "han recordado"},
+      "future_simple": {"yo": "recordaré", "tú": "recordarás", "vos": "recordarás", "él": "recordará", "nosotros": "recordaremos", "vosotros": "recordaréis", "ellos": "recordarán"},
+      "condicional_simple": {"yo": "recordaría", "tú": "recordarías", "vos": "recordarías", "él": "recordaría", "nosotros": "recordaríamos", "vosotros": "recordaríais", "ellos": "recordarían"},
+      "imperfect_indicative": {"yo": "recordaba", "tú": "recordabas", "vos": "recordabas", "él": "recordaba", "nosotros": "recordábamos", "vosotros": "recordabais", "ellos": "recordaban"}
     },
     "conjugations_en": {
       "present": {"I": "remember", "you": "remember", "he": "remembers", "she": "remembers", "it": "remembers", "we": "remember", "they": "remember"},
@@ -1355,12 +1355,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "permito", "tú": "permites", "él": "permite", "nosotros": "permitimos", "vosotros": "permitís", "ellos": "permiten"},
-      "past_simple": {"yo": "permití", "tú": "permitiste", "él": "permitió", "nosotros": "permitimos", "vosotros": "permitisteis", "ellos": "permitieron"},
-      "present_perfect": {"yo": "he permitido", "tú": "has permitido", "él": "ha permitido", "nosotros": "hemos permitido", "vosotros": "habéis permitido", "ellos": "han permitido"},
-      "future_simple": {"yo": "permitiré", "tú": "permitirás", "él": "permitirá", "nosotros": "permitiremos", "vosotros": "permitiréis", "ellos": "permitirán"},
-      "condicional_simple": {"yo": "permitiría", "tú": "permitirías", "él": "permitiría", "nosotros": "permitiríamos", "vosotros": "permitiríais", "ellos": "permitirían"},
-      "imperfect_indicative": {"yo": "permitía", "tú": "permitías", "él": "permitía", "nosotros": "permitíamos", "vosotros": "permitíais", "ellos": "permitían"}
+      "present": {"yo": "permito", "tú": "permites", "vos": "permitís", "él": "permite", "nosotros": "permitimos", "vosotros": "permitís", "ellos": "permiten"},
+      "past_simple": {"yo": "permití", "tú": "permitiste", "vos": "permitiste", "él": "permitió", "nosotros": "permitimos", "vosotros": "permitisteis", "ellos": "permitieron"},
+      "present_perfect": {"yo": "he permitido", "tú": "has permitido", "vos": "has permitido", "él": "ha permitido", "nosotros": "hemos permitido", "vosotros": "habéis permitido", "ellos": "han permitido"},
+      "future_simple": {"yo": "permitiré", "tú": "permitirás", "vos": "permitirás", "él": "permitirá", "nosotros": "permitiremos", "vosotros": "permitiréis", "ellos": "permitirán"},
+      "condicional_simple": {"yo": "permitiría", "tú": "permitirías", "vos": "permitirías", "él": "permitiría", "nosotros": "permitiríamos", "vosotros": "permitiríais", "ellos": "permitirían"},
+      "imperfect_indicative": {"yo": "permitía", "tú": "permitías", "vos": "permitías", "él": "permitía", "nosotros": "permitíamos", "vosotros": "permitíais", "ellos": "permitían"}
     },
     "conjugations_en": {
       "present": {"I": "allow", "you": "allow", "he": "allows", "she": "allows", "it": "allows", "we": "allow", "they": "allow"},
@@ -1383,12 +1383,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "consigo", "tú": "consigues", "él": "consigue", "nosotros": "conseguimos", "vosotros": "conseguís", "ellos": "consiguen"},
-      "past_simple": {"yo": "conseguí", "tú": "conseguiste", "él": "consiguió", "nosotros": "conseguimos", "vosotros": "conseguisteis", "ellos": "consiguieron"},
-      "present_perfect": {"yo": "he conseguido", "tú": "has conseguido", "él": "ha conseguido", "nosotros": "hemos conseguido", "vosotros": "habéis conseguido", "ellos": "han conseguido"},
-      "future_simple": {"yo": "conseguiré", "tú": "conseguirás", "él": "conseguirá", "nosotros": "conseguiremos", "vosotros": "conseguiréis", "ellos": "conseguirán"},
-      "condicional_simple": {"yo": "conseguiría", "tú": "conseguirías", "él": "conseguiría", "nosotros": "conseguiríamos", "vosotros": "conseguiríais", "ellos": "conseguirían"},
-      "imperfect_indicative": {"yo": "conseguía", "tú": "conseguías", "él": "conseguía", "nosotros": "conseguíamos", "vosotros": "conseguíais", "ellos": "conseguían"}
+      "present": {"yo": "consigo", "tú": "consigues", "vos": "conseguís", "él": "consigue", "nosotros": "conseguimos", "vosotros": "conseguís", "ellos": "consiguen"},
+      "past_simple": {"yo": "conseguí", "tú": "conseguiste", "vos": "conseguiste", "él": "consiguió", "nosotros": "conseguimos", "vosotros": "conseguisteis", "ellos": "consiguieron"},
+      "present_perfect": {"yo": "he conseguido", "tú": "has conseguido", "vos": "has conseguido", "él": "ha conseguido", "nosotros": "hemos conseguido", "vosotros": "habéis conseguido", "ellos": "han conseguido"},
+      "future_simple": {"yo": "conseguiré", "tú": "conseguirás", "vos": "conseguirás", "él": "conseguirá", "nosotros": "conseguiremos", "vosotros": "conseguiréis", "ellos": "conseguirán"},
+      "condicional_simple": {"yo": "conseguiría", "tú": "conseguirías", "vos": "conseguirías", "él": "conseguiría", "nosotros": "conseguiríamos", "vosotros": "conseguiríais", "ellos": "conseguirían"},
+      "imperfect_indicative": {"yo": "conseguía", "tú": "conseguías", "vos": "conseguías", "él": "conseguía", "nosotros": "conseguíamos", "vosotros": "conseguíais", "ellos": "conseguían"}
     },
     "conjugations_en": {
       "present": {"I": "get", "you": "get", "he": "gets", "she": "gets", "it": "gets", "we": "get", "they": "get"},
@@ -1411,12 +1411,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "viajo", "tú": "viajas", "él": "viaja", "nosotros": "viajamos", "vosotros": "viajáis", "ellos": "viajan"},
-      "past_simple": {"yo": "viajé", "tú": "viajaste", "él": "viajó", "nosotros": "viajamos", "vosotros": "viajasteis", "ellos": "viajaron"},
-      "present_perfect": {"yo": "he viajado", "tú": "has viajado", "él": "ha viajado", "nosotros": "hemos viajado", "vosotros": "habéis viajado", "ellos": "han viajado"},
-      "future_simple": {"yo": "viajaré", "tú": "viajarás", "él": "viajará", "nosotros": "viajaremos", "vosotros": "viajaréis", "ellos": "viajarán"},
-      "condicional_simple": {"yo": "viajaría", "tú": "viajarías", "él": "viajaría", "nosotros": "viajaríamos", "vosotros": "viajaríais", "ellos": "viajarían"},
-      "imperfect_indicative": {"yo": "viajaba", "tú": "viajabas", "él": "viajaba", "nosotros": "viajábamos", "vosotros": "viajabais", "ellos": "viajaban"}
+      "present": {"yo": "viajo", "tú": "viajas", "vos": "viajás", "él": "viaja", "nosotros": "viajamos", "vosotros": "viajáis", "ellos": "viajan"},
+      "past_simple": {"yo": "viajé", "tú": "viajaste", "vos": "viajaste", "él": "viajó", "nosotros": "viajamos", "vosotros": "viajasteis", "ellos": "viajaron"},
+      "present_perfect": {"yo": "he viajado", "tú": "has viajado", "vos": "has viajado", "él": "ha viajado", "nosotros": "hemos viajado", "vosotros": "habéis viajado", "ellos": "han viajado"},
+      "future_simple": {"yo": "viajaré", "tú": "viajarás", "vos": "viajarás", "él": "viajará", "nosotros": "viajaremos", "vosotros": "viajaréis", "ellos": "viajarán"},
+      "condicional_simple": {"yo": "viajaría", "tú": "viajarías", "vos": "viajarías", "él": "viajaría", "nosotros": "viajaríamos", "vosotros": "viajaríais", "ellos": "viajarían"},
+      "imperfect_indicative": {"yo": "viajaba", "tú": "viajabas", "vos": "viajabas", "él": "viajaba", "nosotros": "viajábamos", "vosotros": "viajabais", "ellos": "viajaban"}
     },
     "conjugations_en": {
       "present": {"I": "travel", "you": "travel", "he": "travels", "she": "travels", "it": "travels", "we": "travel", "they": "travel"},
@@ -1439,12 +1439,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "ayudo", "tú": "ayudas", "él": "ayuda", "nosotros": "ayudamos", "vosotros": "ayudáis", "ellos": "ayudan"},
-      "past_simple": {"yo": "ayudé", "tú": "ayudaste", "él": "ayudó", "nosotros": "ayudamos", "vosotros": "ayudasteis", "ellos": "ayudaron"},
-      "present_perfect": {"yo": "he ayudado", "tú": "has ayudado", "él": "ha ayudado", "nosotros": "hemos ayudado", "vosotros": "habéis ayudado", "ellos": "han ayudado"},
-      "future_simple": {"yo": "ayudaré", "tú": "ayudarás", "él": "ayudará", "nosotros": "ayudaremos", "vosotros": "ayudaréis", "ellos": "ayudarán"},
-      "condicional_simple": {"yo": "ayudaría", "tú": "ayudarías", "él": "ayudaría", "nosotros": "ayudaríamos", "vosotros": "ayudaríais", "ellos": "ayudarían"},
-      "imperfect_indicative": {"yo": "ayudaba", "tú": "ayudabas", "él": "ayudaba", "nosotros": "ayudábamos", "vosotros": "ayudabais", "ellos": "ayudaban"}
+      "present": {"yo": "ayudo", "tú": "ayudas", "vos": "ayudás", "él": "ayuda", "nosotros": "ayudamos", "vosotros": "ayudáis", "ellos": "ayudan"},
+      "past_simple": {"yo": "ayudé", "tú": "ayudaste", "vos": "ayudaste", "él": "ayudó", "nosotros": "ayudamos", "vosotros": "ayudasteis", "ellos": "ayudaron"},
+      "present_perfect": {"yo": "he ayudado", "tú": "has ayudado", "vos": "has ayudado", "él": "ha ayudado", "nosotros": "hemos ayudado", "vosotros": "habéis ayudado", "ellos": "han ayudado"},
+      "future_simple": {"yo": "ayudaré", "tú": "ayudarás", "vos": "ayudarás", "él": "ayudará", "nosotros": "ayudaremos", "vosotros": "ayudaréis", "ellos": "ayudarán"},
+      "condicional_simple": {"yo": "ayudaría", "tú": "ayudarías", "vos": "ayudarías", "él": "ayudaría", "nosotros": "ayudaríamos", "vosotros": "ayudaríais", "ellos": "ayudarían"},
+      "imperfect_indicative": {"yo": "ayudaba", "tú": "ayudabas", "vos": "ayudabas", "él": "ayudaba", "nosotros": "ayudábamos", "vosotros": "ayudabais", "ellos": "ayudaban"}
     },
     "conjugations_en": {
       "present": {"I": "help", "you": "help", "he": "helps", "she": "helps", "it": "helps", "we": "help", "they": "help"},
@@ -1467,12 +1467,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "bebo", "tú": "bebes", "él": "bebe", "nosotros": "bebemos", "vosotros": "bebéis", "ellos": "beben"},
-      "past_simple": {"yo": "bebí", "tú": "bebiste", "él": "bebió", "nosotros": "bebimos", "vosotros": "bebisteis", "ellos": "bebieron"},
-      "present_perfect": {"yo": "he bebido", "tú": "has bebido", "él": "ha bebido", "nosotros": "hemos bebido", "vosotros": "habéis bebido", "ellos": "han bebido"},
-      "future_simple": {"yo": "beberé", "tú": "beberás", "él": "beberá", "nosotros": "beberemos", "vosotros": "beberéis", "ellos": "beberán"},
-      "condicional_simple": {"yo": "bebería", "tú": "beberías", "él": "bebería", "nosotros": "beberíamos", "vosotros": "beberíais", "ellos": "beberían"},
-      "imperfect_indicative": {"yo": "bebía", "tú": "bebías", "él": "bebía", "nosotros": "bebíamos", "vosotros": "bebíais", "ellos": "bebían"}
+      "present": {"yo": "bebo", "tú": "bebes", "vos": "bebés", "él": "bebe", "nosotros": "bebemos", "vosotros": "bebéis", "ellos": "beben"},
+      "past_simple": {"yo": "bebí", "tú": "bebiste", "vos": "bebiste", "él": "bebió", "nosotros": "bebimos", "vosotros": "bebisteis", "ellos": "bebieron"},
+      "present_perfect": {"yo": "he bebido", "tú": "has bebido", "vos": "has bebido", "él": "ha bebido", "nosotros": "hemos bebido", "vosotros": "habéis bebido", "ellos": "han bebido"},
+      "future_simple": {"yo": "beberé", "tú": "beberás", "vos": "beberás", "él": "beberá", "nosotros": "beberemos", "vosotros": "beberéis", "ellos": "beberán"},
+      "condicional_simple": {"yo": "bebería", "tú": "beberías", "vos": "beberías", "él": "bebería", "nosotros": "beberíamos", "vosotros": "beberíais", "ellos": "beberían"},
+      "imperfect_indicative": {"yo": "bebía", "tú": "bebías", "vos": "bebías", "él": "bebía", "nosotros": "bebíamos", "vosotros": "bebíais", "ellos": "bebían"}
     },
     "conjugations_en": {
       "present": {"I": "drink", "you": "drink", "he": "drinks", "she": "drinks", "it": "drinks", "we": "drink", "they": "drink"},
@@ -1495,12 +1495,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "quiero", "tú": "quieres", "él": "quiere", "nosotros": "queremos", "vosotros": "queréis", "ellos": "quieren"},
-      "past_simple": {"yo": "quise", "tú": "quisiste", "él": "quiso", "nosotros": "quisimos", "vosotros": "quisisteis", "ellos": "quisieron"},
-      "present_perfect": {"yo": "he querido", "tú": "has querido", "él": "ha querido", "nosotros": "hemos querido", "vosotros": "habéis querido", "ellos": "han querido"},
-      "future_simple": {"yo": "querré", "tú": "querrás", "él": "querrá", "nosotros": "querremos", "vosotros": "querréis", "ellos": "querrán"},
-      "condicional_simple": {"yo": "querría", "tú": "querrías", "él": "querría", "nosotros": "querríamos", "vosotros": "querríais", "ellos": "querrían"},
-      "imperfect_indicative": {"yo": "quería", "tú": "querías", "él": "quería", "nosotros": "queríamos", "vosotros": "queríais", "ellos": "querían"}
+      "present": {"yo": "quiero", "tú": "quieres", "vos": "querés", "él": "quiere", "nosotros": "queremos", "vosotros": "queréis", "ellos": "quieren"},
+      "past_simple": {"yo": "quise", "tú": "quisiste", "vos": "quisiste", "él": "quiso", "nosotros": "quisimos", "vosotros": "quisisteis", "ellos": "quisieron"},
+      "present_perfect": {"yo": "he querido", "tú": "has querido", "vos": "has querido", "él": "ha querido", "nosotros": "hemos querido", "vosotros": "habéis querido", "ellos": "han querido"},
+      "future_simple": {"yo": "querré", "tú": "querrás", "vos": "querrás", "él": "querrá", "nosotros": "querremos", "vosotros": "querréis", "ellos": "querrán"},
+      "condicional_simple": {"yo": "querría", "tú": "querrías", "vos": "querrías", "él": "querría", "nosotros": "querríamos", "vosotros": "querríais", "ellos": "querrían"},
+      "imperfect_indicative": {"yo": "quería", "tú": "querías", "vos": "querías", "él": "quería", "nosotros": "queríamos", "vosotros": "queríais", "ellos": "querían"}
     },
     "conjugations_en": {
       "present": {"I": "want", "you": "want", "he": "wants", "she": "wants", "it": "wants", "we": "want", "they": "want"},
@@ -1523,12 +1523,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "obtengo", "tú": "obtienes", "él": "obtiene", "nosotros": "obtenemos", "vosotros": "obtenéis", "ellos": "obtienen"},
-      "past_simple": {"yo": "obtuve", "tú": "obtuviste", "él": "obtuvo", "nosotros": "obtuvimos", "vosotros": "obtuvisteis", "ellos": "obtuvieron"},
-      "present_perfect": {"yo": "he obtenido", "tú": "has obtenido", "él": "ha obtenido", "nosotros": "hemos obtenido", "vosotros": "habéis obtenido", "ellos": "han obtenido"},
-      "future_simple": {"yo": "obtendré", "tú": "obtendrás", "él": "obtendrá", "nosotros": "obtendremos", "vosotros": "obtendréis", "ellos": "obtendrán"},
-      "condicional_simple": {"yo": "obtendría", "tú": "obtendrías", "él": "obtendría", "nosotros": "obtendríamos", "vosotros": "obtendríais", "ellos": "obtendrían"},
-      "imperfect_indicative": {"yo": "obtenía", "tú": "obtenías", "él": "obtenía", "nosotros": "obteníamos", "vosotros": "obteníais", "ellos": "obtenían"}
+      "present": {"yo": "obtengo", "tú": "obtienes", "vos": "obtenés", "él": "obtiene", "nosotros": "obtenemos", "vosotros": "obtenéis", "ellos": "obtienen"},
+      "past_simple": {"yo": "obtuve", "tú": "obtuviste", "vos": "obtuviste", "él": "obtuvo", "nosotros": "obtuvimos", "vosotros": "obtuvisteis", "ellos": "obtuvieron"},
+      "present_perfect": {"yo": "he obtenido", "tú": "has obtenido", "vos": "has obtenido", "él": "ha obtenido", "nosotros": "hemos obtenido", "vosotros": "habéis obtenido", "ellos": "han obtenido"},
+      "future_simple": {"yo": "obtendré", "tú": "obtendrás", "vos": "obtendrás", "él": "obtendrá", "nosotros": "obtendremos", "vosotros": "obtendréis", "ellos": "obtendrán"},
+      "condicional_simple": {"yo": "obtendría", "tú": "obtendrías", "vos": "obtendrías", "él": "obtendría", "nosotros": "obtendríamos", "vosotros": "obtendríais", "ellos": "obtendrían"},
+      "imperfect_indicative": {"yo": "obtenía", "tú": "obtenías", "vos": "obtenías", "él": "obtenía", "nosotros": "obteníamos", "vosotros": "obteníais", "ellos": "obtenían"}
     },
     "conjugations_en": {
       "present": {"I": "obtain", "you": "obtain", "he": "obtains", "she": "obtains", "it": "obtains", "we": "obtain", "they": "obtain"},
@@ -1551,12 +1551,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "compongo", "tú": "compones", "él": "compone", "nosotros": "componemos", "vosotros": "componéis", "ellos": "componen"},
-      "past_simple": {"yo": "compuse", "tú": "compusiste", "él": "compuso", "nosotros": "compusimos", "vosotros": "compusisteis", "ellos": "compusieron"},
-      "present_perfect": {"yo": "he compuesto", "tú": "has compuesto", "él": "ha compuesto", "nosotros": "hemos compuesto", "vosotros": "habéis compuesto", "ellos": "han compuesto"},
-      "future_simple": {"yo": "compondré", "tú": "compondrás", "él": "compondrá", "nosotros": "compondremos", "vosotros": "compondréis", "ellos": "compondrán"},
-      "condicional_simple": {"yo": "compondría", "tú": "compondrías", "él": "compondría", "nosotros": "compondríamos", "vosotros": "compondríais", "ellos": "compondrían"},
-      "imperfect_indicative": {"yo": "componía", "tú": "componías", "él": "componía", "nosotros": "componíamos", "vosotros": "componíais", "ellos": "componían"}
+      "present": {"yo": "compongo", "tú": "compones", "vos": "componés", "él": "compone", "nosotros": "componemos", "vosotros": "componéis", "ellos": "componen"},
+      "past_simple": {"yo": "compuse", "tú": "compusiste", "vos": "compusiste", "él": "compuso", "nosotros": "compusimos", "vosotros": "compusisteis", "ellos": "compusieron"},
+      "present_perfect": {"yo": "he compuesto", "tú": "has compuesto", "vos": "has compuesto", "él": "ha compuesto", "nosotros": "hemos compuesto", "vosotros": "habéis compuesto", "ellos": "han compuesto"},
+      "future_simple": {"yo": "compondré", "tú": "compondrás", "vos": "compondrás", "él": "compondrá", "nosotros": "compondremos", "vosotros": "compondréis", "ellos": "compondrán"},
+      "condicional_simple": {"yo": "compondría", "tú": "compondrías", "vos": "compondrías", "él": "compondría", "nosotros": "compondríamos", "vosotros": "compondríais", "ellos": "compondrían"},
+      "imperfect_indicative": {"yo": "componía", "tú": "componías", "vos": "componías", "él": "componía", "nosotros": "componíamos", "vosotros": "componíais", "ellos": "componían"}
     },
     "conjugations_en": {
       "present": {"I": "compose", "you": "compose", "he": "composes", "she": "composes", "it": "composes", "we": "compose", "they": "compose"},
@@ -1579,12 +1579,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "doy", "tú": "das", "él": "da", "nosotros": "damos", "vosotros": "dais", "ellos": "dan"},
-      "past_simple": {"yo": "di", "tú": "diste", "él": "dio", "nosotros": "dimos", "vosotros": "disteis", "ellos": "dieron"},
-      "present_perfect": {"yo": "he dado", "tú": "has dado", "él": "ha dado", "nosotros": "hemos dado", "vosotros": "habéis dado", "ellos": "han dado"},
-      "future_simple": {"yo": "daré", "tú": "darás", "él": "dará", "nosotros": "daremos", "vosotros": "daréis", "ellos": "darán"},
-      "condicional_simple": {"yo": "daría", "tú": "darías", "él": "daría", "nosotros": "daríamos", "vosotros": "daríais", "ellos": "darían"},
-      "imperfect_indicative": {"yo": "daba", "tú": "dabas", "él": "daba", "nosotros": "dábamos", "vosotros": "dabais", "ellos": "daban"}
+      "present": {"yo": "doy", "tú": "das", "vos": "das", "él": "da", "nosotros": "damos", "vosotros": "dais", "ellos": "dan"},
+      "past_simple": {"yo": "di", "tú": "diste", "vos": "diste", "él": "dio", "nosotros": "dimos", "vosotros": "disteis", "ellos": "dieron"},
+      "present_perfect": {"yo": "he dado", "tú": "has dado", "vos": "has dado", "él": "ha dado", "nosotros": "hemos dado", "vosotros": "habéis dado", "ellos": "han dado"},
+      "future_simple": {"yo": "daré", "tú": "darás", "vos": "darás", "él": "dará", "nosotros": "daremos", "vosotros": "daréis", "ellos": "darán"},
+      "condicional_simple": {"yo": "daría", "tú": "darías", "vos": "darías", "él": "daría", "nosotros": "daríamos", "vosotros": "daríais", "ellos": "darían"},
+      "imperfect_indicative": {"yo": "daba", "tú": "dabas", "vos": "dabas", "él": "daba", "nosotros": "dábamos", "vosotros": "dabais", "ellos": "daban"}
     },
     "conjugations_en": {
       "present": {"I": "give", "you": "give", "he": "gives", "she": "gives", "it": "gives", "we": "give", "they": "give"},
@@ -1607,12 +1607,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "miento", "tú": "mientes", "él": "miente", "nosotros": "mentimos", "vosotros": "mentís", "ellos": "mienten"},
-      "past_simple": {"yo": "mentí", "tú": "mentiste", "él": "mintió", "nosotros": "mentimos", "vosotros": "mentisteis", "ellos": "mintieron"},
-      "present_perfect": {"yo": "he mentido", "tú": "has mentido", "él": "ha mentido", "nosotros": "hemos mentido", "vosotros": "habéis mentido", "ellos": "han mentido"},
-      "future_simple": {"yo": "mentiré", "tú": "mentirás", "él": "mentirá", "nosotros": "mentiremos", "vosotros": "mentiréis", "ellos": "mentirán"},
-      "condicional_simple": {"yo": "mentiría", "tú": "mentirías", "él": "mentiría", "nosotros": "mentiríamos", "vosotros": "mentiríais", "ellos": "mentirían"},
-      "imperfect_indicative": {"yo": "mentía", "tú": "mentías", "él": "mentía", "nosotros": "mentíamos", "vosotros": "mentíais", "ellos": "mentían"}
+      "present": {"yo": "miento", "tú": "mientes", "vos": "mentís", "él": "miente", "nosotros": "mentimos", "vosotros": "mentís", "ellos": "mienten"},
+      "past_simple": {"yo": "mentí", "tú": "mentiste", "vos": "mentiste", "él": "mintió", "nosotros": "mentimos", "vosotros": "mentisteis", "ellos": "mintieron"},
+      "present_perfect": {"yo": "he mentido", "tú": "has mentido", "vos": "has mentido", "él": "ha mentido", "nosotros": "hemos mentido", "vosotros": "habéis mentido", "ellos": "han mentido"},
+      "future_simple": {"yo": "mentiré", "tú": "mentirás", "vos": "mentirás", "él": "mentirá", "nosotros": "mentiremos", "vosotros": "mentiréis", "ellos": "mentirán"},
+      "condicional_simple": {"yo": "mentiría", "tú": "mentirías", "vos": "mentirías", "él": "mentiría", "nosotros": "mentiríamos", "vosotros": "mentiríais", "ellos": "mentirían"},
+      "imperfect_indicative": {"yo": "mentía", "tú": "mentías", "vos": "mentías", "él": "mentía", "nosotros": "mentíamos", "vosotros": "mentíais", "ellos": "mentían"}
     },
     "conjugations_en": {
       "present": {"I": "lie", "you": "lie", "he": "lies", "she": "lies", "it": "lies", "we": "lie", "they": "lie"},
@@ -1635,12 +1635,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me comunico", "tú": "te comunicas", "él": "se comunica", "nosotros": "nos comunicamos", "vosotros": "os comunicáis", "ellos": "se comunican"},
-      "past_simple": {"yo": "me comuniqué", "tú": "te comunicaste", "él": "se comunicó", "nosotros": "nos comunicamos", "vosotros": "os comunicasteis", "ellos": "se comunicaron"},
-      "present_perfect": {"yo": "me he comunicado", "tú": "te has comunicado", "él": "se ha comunicado", "nosotros": "nos hemos comunicado", "vosotros": "os habéis comunicado", "ellos": "se han comunicado"},
-      "future_simple": {"yo": "me comunicaré", "tú": "te comunicarás", "él": "se comunicará", "nosotros": "nos comunicaremos", "vosotros": "os comunicaréis", "ellos": "se comunicarán"},
-      "condicional_simple": {"yo": "me comunicaría", "tú": "te comunicarías", "él": "se comunicaría", "nosotros": "nos comunicaríamos", "vosotros": "os comunicaríais", "ellos": "se comunicarían"},
-      "imperfect_indicative": {"yo": "me comunicaba", "tú": "te comunicabas", "él": "se comunicaba", "nosotros": "nos comunicábamos", "vosotros": "os comunicabais", "ellos": "se comunicaban"}
+      "present": {"yo": "me comunico", "tú": "te comunicas", "vos": "te comunicás", "él": "se comunica", "nosotros": "nos comunicamos", "vosotros": "os comunicáis", "ellos": "se comunican"},
+      "past_simple": {"yo": "me comuniqué", "tú": "te comunicaste", "vos": "te comunicaste", "él": "se comunicó", "nosotros": "nos comunicamos", "vosotros": "os comunicasteis", "ellos": "se comunicaron"},
+      "present_perfect": {"yo": "me he comunicado", "tú": "te has comunicado", "vos": "te has comunicado", "él": "se ha comunicado", "nosotros": "nos hemos comunicado", "vosotros": "os habéis comunicado", "ellos": "se han comunicado"},
+      "future_simple": {"yo": "me comunicaré", "tú": "te comunicarás", "vos": "te comunicarás", "él": "se comunicará", "nosotros": "nos comunicaremos", "vosotros": "os comunicaréis", "ellos": "se comunicarán"},
+      "condicional_simple": {"yo": "me comunicaría", "tú": "te comunicarías", "vos": "te comunicarías", "él": "se comunicaría", "nosotros": "nos comunicaríamos", "vosotros": "os comunicaríais", "ellos": "se comunicarían"},
+      "imperfect_indicative": {"yo": "me comunicaba", "tú": "te comunicabas", "vos": "te comunicabas", "él": "se comunicaba", "nosotros": "nos comunicábamos", "vosotros": "os comunicabais", "ellos": "se comunicaban"}
     },
     "conjugations_en": {
       "present": {"I": "communicate", "you": "communicate", "he": "communicates", "she": "communicates", "it": "communicates", "we": "communicate", "they": "communicate"},
@@ -1663,12 +1663,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me mudo", "tú": "te mudas", "él": "se muda", "nosotros": "nos mudamos", "vosotros": "os mudáis", "ellos": "se mudan"},
-      "past_simple": {"yo": "me mudé", "tú": "te mudaste", "él": "se mudó", "nosotros": "nos mudamos", "vosotros": "os mudasteis", "ellos": "se mudaron"},
-      "present_perfect": {"yo": "me he mudado", "tú": "te has mudado", "él": "se ha mudado", "nosotros": "nos hemos mudado", "vosotros": "os habéis mudado", "ellos": "se han mudado"},
-      "future_simple": {"yo": "me mudaré", "tú": "te mudarás", "él": "se mudará", "nosotros": "nos mudaremos", "vosotros": "os mudaréis", "ellos": "se mudarán"},
-      "condicional_simple": {"yo": "me mudaría", "tú": "te mudarías", "él": "se mudaría", "nosotros": "nos mudaríamos", "vosotros": "os mudaríais", "ellos": "se mudarían"},
-      "imperfect_indicative": {"yo": "me mudaba", "tú": "te mudabas", "él": "se mudaba", "nosotros": "nos mudábamos", "vosotros": "os mudabais", "ellos": "se mudaban"}
+      "present": {"yo": "me mudo", "tú": "te mudas", "vos": "te mudás", "él": "se muda", "nosotros": "nos mudamos", "vosotros": "os mudáis", "ellos": "se mudan"},
+      "past_simple": {"yo": "me mudé", "tú": "te mudaste", "vos": "te mudaste", "él": "se mudó", "nosotros": "nos mudamos", "vosotros": "os mudasteis", "ellos": "se mudaron"},
+      "present_perfect": {"yo": "me he mudado", "tú": "te has mudado", "vos": "te has mudado", "él": "se ha mudado", "nosotros": "nos hemos mudado", "vosotros": "os habéis mudado", "ellos": "se han mudado"},
+      "future_simple": {"yo": "me mudaré", "tú": "te mudarás", "vos": "te mudarás", "él": "se mudará", "nosotros": "nos mudaremos", "vosotros": "os mudaréis", "ellos": "se mudarán"},
+      "condicional_simple": {"yo": "me mudaría", "tú": "te mudarías", "vos": "te mudarías", "él": "se mudaría", "nosotros": "nos mudaríamos", "vosotros": "os mudaríais", "ellos": "se mudarían"},
+      "imperfect_indicative": {"yo": "me mudaba", "tú": "te mudabas", "vos": "te mudabas", "él": "se mudaba", "nosotros": "nos mudábamos", "vosotros": "os mudabais", "ellos": "se mudaban"}
     },
     "conjugations_en": {
       "present": {"I": "move", "you": "move", "he": "moves", "she": "moves", "it": "moves", "we": "move", "they": "move"},
@@ -1691,12 +1691,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me ducho", "tú": "te duchas", "él": "se ducha", "nosotros": "nos duchamos", "vosotros": "os ducháis", "ellos": "se duchan"},
-      "past_simple": {"yo": "me duché", "tú": "te duchaste", "él": "se duchó", "nosotros": "nos duchamos", "vosotros": "os duchasteis", "ellos": "se ducharon"},
-      "present_perfect": {"yo": "me he duchado", "tú": "te has duchado", "él": "se ha duchado", "nosotros": "nos hemos duchado", "vosotros": "os habéis duchado", "ellos": "se han duchado"},
-      "future_simple": {"yo": "me ducharé", "tú": "te ducharás", "él": "se duchará", "nosotros": "nos ducharemos", "vosotros": "os ducharéis", "ellos": "se ducharán"},
-      "condicional_simple": {"yo": "me ducharía", "tú": "te ducharías", "él": "se ducharía", "nosotros": "nos ducharíamos", "vosotros": "os ducharíais", "ellos": "se ducharían"},
-      "imperfect_indicative": {"yo": "me duchaba", "tú": "te duchabas", "él": "se duchaba", "nosotros": "nos duchábamos", "vosotros": "os duchabais", "ellos": "se duchaban"}
+      "present": {"yo": "me ducho", "tú": "te duchas", "vos": "te duchás", "él": "se ducha", "nosotros": "nos duchamos", "vosotros": "os ducháis", "ellos": "se duchan"},
+      "past_simple": {"yo": "me duché", "tú": "te duchaste", "vos": "te duchaste", "él": "se duchó", "nosotros": "nos duchamos", "vosotros": "os duchasteis", "ellos": "se ducharon"},
+      "present_perfect": {"yo": "me he duchado", "tú": "te has duchado", "vos": "te has duchado", "él": "se ha duchado", "nosotros": "nos hemos duchado", "vosotros": "os habéis duchado", "ellos": "se han duchado"},
+      "future_simple": {"yo": "me ducharé", "tú": "te ducharás", "vos": "te ducharás", "él": "se duchará", "nosotros": "nos ducharemos", "vosotros": "os ducharéis", "ellos": "se ducharán"},
+      "condicional_simple": {"yo": "me ducharía", "tú": "te ducharías", "vos": "te ducharías", "él": "se ducharía", "nosotros": "nos ducharíamos", "vosotros": "os ducharíais", "ellos": "se ducharían"},
+      "imperfect_indicative": {"yo": "me duchaba", "tú": "te duchabas", "vos": "te duchabas", "él": "se duchaba", "nosotros": "nos duchábamos", "vosotros": "os duchabais", "ellos": "se duchaban"}
     },
     "conjugations_en": {
       "present": {"I": "take a shower", "you": "take a shower", "he": "takes a shower", "she": "takes a shower", "it": "takes a shower", "we": "take a shower", "they": "take a shower"},
@@ -1719,12 +1719,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me acuesto", "tú": "te acuestas", "él": "se acuesta", "nosotros": "nos acostamos", "vosotros": "os acostáis", "ellos": "se acuestan"},
-      "past_simple": {"yo": "me acosté", "tú": "te acostaste", "él": "se acostó", "nosotros": "nos acostamos", "vosotros": "os acostasteis", "ellos": "se acostaron"},
-      "present_perfect": {"yo": "me he acostado", "tú": "te has acostado", "él": "se ha acostado", "nosotros": "nos hemos acostado", "vosotros": "os habéis acostado", "ellos": "se han acostado"},
-      "future_simple": {"yo": "me acostaré", "tú": "te acostarás", "él": "se acostará", "nosotros": "nos acostaremos", "vosotros": "os acostaréis", "ellos": "se acostarán"},
-      "condicional_simple": {"yo": "me acostaría", "tú": "te acostarías", "él": "se acostaría", "nosotros": "nos acostaríamos", "vosotros": "os acostaríais", "ellos": "se acostarían"},
-      "imperfect_indicative": {"yo": "me acostaba", "tú": "te acostabas", "él": "se acostaba", "nosotros": "nos acostábamos", "vosotros": "os acostabais", "ellos": "se acostaban"}
+      "present": {"yo": "me acuesto", "tú": "te acuestas", "vos": "te acostás", "él": "se acuesta", "nosotros": "nos acostamos", "vosotros": "os acostáis", "ellos": "se acuestan"},
+      "past_simple": {"yo": "me acosté", "tú": "te acostaste", "vos": "te acostaste", "él": "se acostó", "nosotros": "nos acostamos", "vosotros": "os acostasteis", "ellos": "se acostaron"},
+      "present_perfect": {"yo": "me he acostado", "tú": "te has acostado", "vos": "te has acostado", "él": "se ha acostado", "nosotros": "nos hemos acostado", "vosotros": "os habéis acostado", "ellos": "se han acostado"},
+      "future_simple": {"yo": "me acostaré", "tú": "te acostarás", "vos": "te acostarás", "él": "se acostará", "nosotros": "nos acostaremos", "vosotros": "os acostaréis", "ellos": "se acostarán"},
+      "condicional_simple": {"yo": "me acostaría", "tú": "te acostarías", "vos": "te acostarías", "él": "se acostaría", "nosotros": "nos acostaríamos", "vosotros": "os acostaríais", "ellos": "se acostarían"},
+      "imperfect_indicative": {"yo": "me acostaba", "tú": "te acostabas", "vos": "te acostabas", "él": "se acostaba", "nosotros": "nos acostábamos", "vosotros": "os acostabais", "ellos": "se acostaban"}
     },
     "conjugations_en": {
       "present": {"I": "go to bed", "you": "go to bed", "he": "goes to bed", "she": "goes to bed", "it": "goes to bed", "we": "go to bed", "they": "go to bed"},
@@ -1747,12 +1747,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me levanto", "tú": "te levantas", "él": "se levanta", "nosotros": "nos levantamos", "vosotros": "os levantáis", "ellos": "se levantan"},
-      "past_simple": {"yo": "me levanté", "tú": "te levantaste", "él": "se levantó", "nosotros": "nos levantamos", "vosotros": "os levantasteis", "ellos": "se levantaron"},
-      "present_perfect": {"yo": "me he levantado", "tú": "te has levantado", "él": "se ha levantado", "nosotros": "nos hemos levantado", "vosotros": "os habéis levantado", "ellos": "se han levantado"},
-      "future_simple": {"yo": "me levantaré", "tú": "te levantarás", "él": "se levantará", "nosotros": "nos levantaremos", "vosotros": "os levantaréis", "ellos": "se levantarán"},
-      "condicional_simple": {"yo": "me levantaría", "tú": "te levantarías", "él": "se levantaría", "nosotros": "nos levantaríamos", "vosotros": "os levantaríais", "ellos": "se levantarían"},
-      "imperfect_indicative": {"yo": "me levantaba", "tú": "te levantabas", "él": "se levantaba", "nosotros": "nos levantábamos", "vosotros": "os levantabais", "ellos": "se levantaban"}
+      "present": {"yo": "me levanto", "tú": "te levantas", "vos": "te levantás", "él": "se levanta", "nosotros": "nos levantamos", "vosotros": "os levantáis", "ellos": "se levantan"},
+      "past_simple": {"yo": "me levanté", "tú": "te levantaste", "vos": "te levantaste", "él": "se levantó", "nosotros": "nos levantamos", "vosotros": "os levantasteis", "ellos": "se levantaron"},
+      "present_perfect": {"yo": "me he levantado", "tú": "te has levantado", "vos": "te has levantado", "él": "se ha levantado", "nosotros": "nos hemos levantado", "vosotros": "os habéis levantado", "ellos": "se han levantado"},
+      "future_simple": {"yo": "me levantaré", "tú": "te levantarás", "vos": "te levantarás", "él": "se levantará", "nosotros": "nos levantaremos", "vosotros": "os levantaréis", "ellos": "se levantarán"},
+      "condicional_simple": {"yo": "me levantaría", "tú": "te levantarías", "vos": "te levantarías", "él": "se levantaría", "nosotros": "nos levantaríamos", "vosotros": "os levantaríais", "ellos": "se levantarían"},
+      "imperfect_indicative": {"yo": "me levantaba", "tú": "te levantabas", "vos": "te levantabas", "él": "se levantaba", "nosotros": "nos levantábamos", "vosotros": "os levantabais", "ellos": "se levantaban"}
     },
     "conjugations_en": {
       "present": {"I": "get up", "you": "get up", "he": "gets up", "she": "gets up", "it": "gets up", "we": "get up", "they": "get up"},
@@ -1775,12 +1775,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "supongo", "tú": "supones", "él": "supone", "nosotros": "suponemos", "vosotros": "suponéis", "ellos": "suponen"},
-      "past_simple": {"yo": "supuse", "tú": "supusiste", "él": "supuso", "nosotros": "supusimos", "vosotros": "supusisteis", "ellos": "supusieron"},
-      "present_perfect": {"yo": "he supuesto", "tú": "has supuesto", "él": "ha supuesto", "nosotros": "hemos supuesto", "vosotros": "habéis supuesto", "ellos": "han supuesto"},
-      "future_simple": {"yo": "supondré", "tú": "supondrás", "él": "supondrá", "nosotros": "supondremos", "vosotros": "supondréis", "ellos": "supondrán"},
-      "condicional_simple": {"yo": "supondría", "tú": "supondrías", "él": "supondría", "nosotros": "supondríamos", "vosotros": "supondríais", "ellos": "supondrían"},
-      "imperfect_indicative": {"yo": "suponía", "tú": "suponías", "él": "suponía", "nosotros": "suponíamos", "vosotros": "suponíais", "ellos": "suponían"}
+      "present": {"yo": "supongo", "tú": "supones", "vos": "suponés", "él": "supone", "nosotros": "suponemos", "vosotros": "suponéis", "ellos": "suponen"},
+      "past_simple": {"yo": "supuse", "tú": "supusiste", "vos": "supusiste", "él": "supuso", "nosotros": "supusimos", "vosotros": "supusisteis", "ellos": "supusieron"},
+      "present_perfect": {"yo": "he supuesto", "tú": "has supuesto", "vos": "has supuesto", "él": "ha supuesto", "nosotros": "hemos supuesto", "vosotros": "habéis supuesto", "ellos": "han supuesto"},
+      "future_simple": {"yo": "supondré", "tú": "supondrás", "vos": "supondrás", "él": "supondrá", "nosotros": "supondremos", "vosotros": "supondréis", "ellos": "supondrán"},
+      "condicional_simple": {"yo": "supondría", "tú": "supondrías", "vos": "supondrías", "él": "supondría", "nosotros": "supondríamos", "vosotros": "supondríais", "ellos": "supondrían"},
+      "imperfect_indicative": {"yo": "suponía", "tú": "suponías", "vos": "suponías", "él": "suponía", "nosotros": "suponíamos", "vosotros": "suponíais", "ellos": "suponían"}
     },
     "conjugations_en": {
       "present": {"I": "suppose", "you": "suppose", "he": "supposes", "she": "supposes", "it": "supposes", "we": "suppose", "they": "suppose"},
@@ -1803,12 +1803,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "traigo", "tú": "traes", "él": "trae", "nosotros": "traemos", "vosotros": "traéis", "ellos": "traen"},
-      "past_simple": {"yo": "traje", "tú": "trajiste", "él": "trajo", "nosotros": "trajimos", "vosotros": "trajisteis", "ellos": "trajeron"},
-      "present_perfect": {"yo": "he traído", "tú": "has traído", "él": "ha traído", "nosotros": "hemos traído", "vosotros": "habéis traído", "ellos": "han traído"},
-      "future_simple": {"yo": "traeré", "tú": "traerás", "él": "traerá", "nosotros": "traeremos", "vosotros": "traeréis", "ellos": "traerán"},
-      "condicional_simple": {"yo": "traería", "tú": "traerías", "él": "traería", "nosotros": "traeríamos", "vosotros": "traeríais", "ellos": "traerían"},
-      "imperfect_indicative": {"yo": "traía", "tú": "traías", "él": "traía", "nosotros": "traíamos", "vosotros": "traíais", "ellos": "traían"}
+      "present": {"yo": "traigo", "tú": "traes", "vos": "traés", "él": "trae", "nosotros": "traemos", "vosotros": "traéis", "ellos": "traen"},
+      "past_simple": {"yo": "traje", "tú": "trajiste", "vos": "trajiste", "él": "trajo", "nosotros": "trajimos", "vosotros": "trajisteis", "ellos": "trajeron"},
+      "present_perfect": {"yo": "he traído", "tú": "has traído", "vos": "has traído", "él": "ha traído", "nosotros": "hemos traído", "vosotros": "habéis traído", "ellos": "han traído"},
+      "future_simple": {"yo": "traeré", "tú": "traerás", "vos": "traerás", "él": "traerá", "nosotros": "traeremos", "vosotros": "traeréis", "ellos": "traerán"},
+      "condicional_simple": {"yo": "traería", "tú": "traerías", "vos": "traerías", "él": "traería", "nosotros": "traeríamos", "vosotros": "traeríais", "ellos": "traerían"},
+      "imperfect_indicative": {"yo": "traía", "tú": "traías", "vos": "traías", "él": "traía", "nosotros": "traíamos", "vosotros": "traíais", "ellos": "traían"}
     },
     "conjugations_en": {
       "present": {"I": "bring", "you": "bring", "he": "brings", "she": "brings", "it": "brings", "we": "bring", "they": "bring"},
@@ -1831,12 +1831,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "pierdo", "tú": "pierdes", "él": "pierde", "nosotros": "perdemos", "vosotros": "perdéis", "ellos": "pierden"},
-      "past_simple": {"yo": "perdí", "tú": "perdiste", "él": "perdió", "nosotros": "perdimos", "vosotros": "perdisteis", "ellos": "perdieron"},
-      "present_perfect": {"yo": "he perdido", "tú": "has perdido", "él": "ha perdido", "nosotros": "hemos perdido", "vosotros": "habéis perdido", "ellos": "han perdido"},
-      "future_simple": {"yo": "perderé", "tú": "perderás", "él": "perderá", "nosotros": "perderemos", "vosotros": "perderéis", "ellos": "perderán"},
-      "condicional_simple": {"yo": "perdería", "tú": "perderías", "él": "perdería", "nosotros": "perderíamos", "vosotros": "perderíais", "ellos": "perderían"},
-      "imperfect_indicative": {"yo": "perdía", "tú": "perdías", "él": "perdía", "nosotros": "perdíamos", "vosotros": "perdíais", "ellos": "perdían"}
+      "present": {"yo": "pierdo", "tú": "pierdes", "vos": "perdés", "él": "pierde", "nosotros": "perdemos", "vosotros": "perdéis", "ellos": "pierden"},
+      "past_simple": {"yo": "perdí", "tú": "perdiste", "vos": "perdiste", "él": "perdió", "nosotros": "perdimos", "vosotros": "perdisteis", "ellos": "perdieron"},
+      "present_perfect": {"yo": "he perdido", "tú": "has perdido", "vos": "has perdido", "él": "ha perdido", "nosotros": "hemos perdido", "vosotros": "habéis perdido", "ellos": "han perdido"},
+      "future_simple": {"yo": "perderé", "tú": "perderás", "vos": "perderás", "él": "perderá", "nosotros": "perderemos", "vosotros": "perderéis", "ellos": "perderán"},
+      "condicional_simple": {"yo": "perdería", "tú": "perderías", "vos": "perderías", "él": "perdería", "nosotros": "perderíamos", "vosotros": "perderíais", "ellos": "perderían"},
+      "imperfect_indicative": {"yo": "perdía", "tú": "perdías", "vos": "perdías", "él": "perdía", "nosotros": "perdíamos", "vosotros": "perdíais", "ellos": "perdían"}
     },
     "conjugations_en": {
       "present": {"I": "lose", "you": "lose", "he": "loses", "she": "loses", "it": "loses", "we": "lose", "they": "lose"},
@@ -1859,12 +1859,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "caigo", "tú": "caes", "él": "cae", "nosotros": "caemos", "vosotros": "caéis", "ellos": "caen"},
-      "past_simple": {"yo": "caí", "tú": "caíste", "él": "cayó", "nosotros": "caímos", "vosotros": "caísteis", "ellos": "cayeron"},
-      "present_perfect": {"yo": "he caído", "tú": "has caído", "él": "ha caído", "nosotros": "hemos caído", "vosotros": "habéis caído", "ellos": "han caído"},
-      "future_simple": {"yo": "caeré", "tú": "caerás", "él": "caerá", "nosotros": "caeremos", "vosotros": "caeréis", "ellos": "caerán"},
-      "condicional_simple": {"yo": "caería", "tú": "caerías", "él": "caería", "nosotros": "caeríamos", "vosotros": "caeríais", "ellos": "caerían"},
-      "imperfect_indicative": {"yo": "caía", "tú": "caías", "él": "caía", "nosotros": "caíamos", "vosotros": "caíais", "ellos": "caían"}
+      "present": {"yo": "caigo", "tú": "caes", "vos": "caés", "él": "cae", "nosotros": "caemos", "vosotros": "caéis", "ellos": "caen"},
+      "past_simple": {"yo": "caí", "tú": "caíste", "vos": "caíste", "él": "cayó", "nosotros": "caímos", "vosotros": "caísteis", "ellos": "cayeron"},
+      "present_perfect": {"yo": "he caído", "tú": "has caído", "vos": "has caído", "él": "ha caído", "nosotros": "hemos caído", "vosotros": "habéis caído", "ellos": "han caído"},
+      "future_simple": {"yo": "caeré", "tú": "caerás", "vos": "caerás", "él": "caerá", "nosotros": "caeremos", "vosotros": "caeréis", "ellos": "caerán"},
+      "condicional_simple": {"yo": "caería", "tú": "caerías", "vos": "caerías", "él": "caería", "nosotros": "caeríamos", "vosotros": "caeríais", "ellos": "caerían"},
+      "imperfect_indicative": {"yo": "caía", "tú": "caías", "vos": "caías", "él": "caía", "nosotros": "caíamos", "vosotros": "caíais", "ellos": "caían"}
     },
     "conjugations_en": {
       "present": {"I": "fall", "you": "fall", "he": "falls", "she": "falls", "it": "falls", "we": "fall", "they": "fall"},
@@ -1887,12 +1887,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "ando", "tú": "andas", "él": "anda", "nosotros": "andamos", "vosotros": "andáis", "ellos": "andan"},
-      "past_simple": {"yo": "anduve", "tú": "anduviste", "él": "anduvo", "nosotros": "anduvimos", "vosotros": "anduvisteis", "ellos": "anduvieron"},
-      "present_perfect": {"yo": "he andado", "tú": "has andado", "él": "ha andado", "nosotros": "hemos andado", "vosotros": "habéis andado", "ellos": "han andado"},
-      "future_simple": {"yo": "andaré", "tú": "andarás", "él": "andará", "nosotros": "andaremos", "vosotros": "andaréis", "ellos": "andarán"},
-      "condicional_simple": {"yo": "andaría", "tú": "andarías", "él": "andaría", "nosotros": "andaríamos", "vosotros": "andaríais", "ellos": "andarían"},
-      "imperfect_indicative": {"yo": "andaba", "tú": "andabas", "él": "andaba", "nosotros": "andábamos", "vosotros": "andabais", "ellos": "andaban"}
+      "present": {"yo": "ando", "tú": "andas", "vos": "andás", "él": "anda", "nosotros": "andamos", "vosotros": "andáis", "ellos": "andan"},
+      "past_simple": {"yo": "anduve", "tú": "anduviste", "vos": "anduviste", "él": "anduvo", "nosotros": "anduvimos", "vosotros": "anduvisteis", "ellos": "anduvieron"},
+      "present_perfect": {"yo": "he andado", "tú": "has andado", "vos": "has andado", "él": "ha andado", "nosotros": "hemos andado", "vosotros": "habéis andado", "ellos": "han andado"},
+      "future_simple": {"yo": "andaré", "tú": "andarás", "vos": "andarás", "él": "andará", "nosotros": "andaremos", "vosotros": "andaréis", "ellos": "andarán"},
+      "condicional_simple": {"yo": "andaría", "tú": "andarías", "vos": "andarías", "él": "andaría", "nosotros": "andaríamos", "vosotros": "andaríais", "ellos": "andarían"},
+      "imperfect_indicative": {"yo": "andaba", "tú": "andabas", "vos": "andabas", "él": "andaba", "nosotros": "andábamos", "vosotros": "andabais", "ellos": "andaban"}
     },
     "conjugations_en": {
       "present": {"I": "walk", "you": "walk", "he": "walks", "she": "walks", "it": "walks", "we": "walk", "they": "walk"},
@@ -1915,12 +1915,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "busco", "tú": "buscas", "él": "busca", "nosotros": "buscamos", "vosotros": "buscáis", "ellos": "buscan"},
-      "past_simple": {"yo": "busqué", "tú": "buscaste", "él": "buscó", "nosotros": "buscamos", "vosotros": "buscasteis", "ellos": "buscaron"},
-      "present_perfect": {"yo": "he buscado", "tú": "has buscado", "él": "ha buscado", "nosotros": "hemos buscado", "vosotros": "habéis buscado", "ellos": "han buscado"},
-      "future_simple": {"yo": "buscaré", "tú": "buscarás", "él": "buscará", "nosotros": "buscaremos", "vosotros": "buscaréis", "ellos": "buscarán"},
-      "condicional_simple": {"yo": "buscaría", "tú": "buscarías", "él": "buscaría", "nosotros": "buscaríamos", "vosotros": "buscaríais", "ellos": "buscarían"},
-      "imperfect_indicative": {"yo": "buscaba", "tú": "buscabas", "él": "buscaba", "nosotros": "buscábamos", "vosotros": "buscabais", "ellos": "buscaban"}
+      "present": {"yo": "busco", "tú": "buscas", "vos": "buscás", "él": "busca", "nosotros": "buscamos", "vosotros": "buscáis", "ellos": "buscan"},
+      "past_simple": {"yo": "busqué", "tú": "buscaste", "vos": "buscaste", "él": "buscó", "nosotros": "buscamos", "vosotros": "buscasteis", "ellos": "buscaron"},
+      "present_perfect": {"yo": "he buscado", "tú": "has buscado", "vos": "has buscado", "él": "ha buscado", "nosotros": "hemos buscado", "vosotros": "habéis buscado", "ellos": "han buscado"},
+      "future_simple": {"yo": "buscaré", "tú": "buscarás", "vos": "buscarás", "él": "buscará", "nosotros": "buscaremos", "vosotros": "buscaréis", "ellos": "buscarán"},
+      "condicional_simple": {"yo": "buscaría", "tú": "buscarías", "vos": "buscarías", "él": "buscaría", "nosotros": "buscaríamos", "vosotros": "buscaríais", "ellos": "buscarían"},
+      "imperfect_indicative": {"yo": "buscaba", "tú": "buscabas", "vos": "buscabas", "él": "buscaba", "nosotros": "buscábamos", "vosotros": "buscabais", "ellos": "buscaban"}
     },
     "conjugations_en": {
       "present": {"I": "search", "you": "search", "he": "searches", "she": "searches", "it": "searches", "we": "search", "they": "search"},
@@ -1943,12 +1943,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me siento", "tú": "te sientas", "él": "se sienta", "nosotros": "nos sentamos", "vosotros": "os sentáis", "ellos": "se sientan"},
-      "past_simple": {"yo": "me senté", "tú": "te sentaste", "él": "se sentó", "nosotros": "nos sentamos", "vosotros": "os sentasteis", "ellos": "se sentaron"},
-      "present_perfect": {"yo": "me he sentado", "tú": "te has sentado", "él": "se ha sentado", "nosotros": "nos hemos sentado", "vosotros": "os habéis sentado", "ellos": "se han sentado"},
-      "future_simple": {"yo": "me sentaré", "tú": "te sentarás", "él": "se sentará", "nosotros": "nos sentaremos", "vosotros": "os sentaréis", "ellos": "se sentarán"},
-      "condicional_simple": {"yo": "me sentaría", "tú": "te sentarías", "él": "se sentaría", "nosotros": "nos sentaríamos", "vosotros": "os sentaríais", "ellos": "se sentarían"},
-      "imperfect_indicative": {"yo": "me sentaba", "tú": "te sentabas", "él": "se sentaba", "nosotros": "nos sentábamos", "vosotros": "os sentabais", "ellos": "se sentaban"}
+      "present": {"yo": "me siento", "tú": "te sientas", "vos": "te sentás", "él": "se sienta", "nosotros": "nos sentamos", "vosotros": "os sentáis", "ellos": "se sientan"},
+      "past_simple": {"yo": "me senté", "tú": "te sentaste", "vos": "te sentaste", "él": "se sentó", "nosotros": "nos sentamos", "vosotros": "os sentasteis", "ellos": "se sentaron"},
+      "present_perfect": {"yo": "me he sentado", "tú": "te has sentado", "vos": "te has sentado", "él": "se ha sentado", "nosotros": "nos hemos sentado", "vosotros": "os habéis sentado", "ellos": "se han sentado"},
+      "future_simple": {"yo": "me sentaré", "tú": "te sentarás", "vos": "te sentarás", "él": "se sentará", "nosotros": "nos sentaremos", "vosotros": "os sentaréis", "ellos": "se sentarán"},
+      "condicional_simple": {"yo": "me sentaría", "tú": "te sentarías", "vos": "te sentarías", "él": "se sentaría", "nosotros": "nos sentaríamos", "vosotros": "os sentaríais", "ellos": "se sentarían"},
+      "imperfect_indicative": {"yo": "me sentaba", "tú": "te sentabas", "vos": "te sentabas", "él": "se sentaba", "nosotros": "nos sentábamos", "vosotros": "os sentabais", "ellos": "se sentaban"}
     },
     "conjugations_en": {
       "present": {"I": "sit down", "you": "sit down", "he": "sits down", "she": "sits down", "it": "sits down", "we": "sit down", "they": "sit down"},
@@ -1971,12 +1971,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "conduzco", "tú": "conduces", "él": "conduce", "nosotros": "conducimos", "vosotros": "conducís", "ellos": "conducen"},
-      "past_simple": {"yo": "conduje", "tú": "condujiste", "él": "condujo", "nosotros": "condujimos", "vosotros": "condujisteis", "ellos": "condujeron"},
-      "present_perfect": {"yo": "he conducido", "tú": "has conducido", "él": "ha conducido", "nosotros": "hemos conducido", "vosotros": "habéis conducido", "ellos": "han conducido"},
-      "future_simple": {"yo": "conduciré", "tú": "conducirás", "él": "conducirá", "nosotros": "conduciremos", "vosotros": "conduciréis", "ellos": "conducirán"},
-      "condicional_simple": {"yo": "conduciría", "tú": "conducirías", "él": "conduciría", "nosotros": "conduciríamos", "vosotros": "conduciríais", "ellos": "conducirían"},
-      "imperfect_indicative": {"yo": "conducía", "tú": "conducías", "él": "conducía", "nosotros": "conducíamos", "vosotros": "conducíais", "ellos": "conducían"}
+      "present": {"yo": "conduzco", "tú": "conduces", "vos": "conducís", "él": "conduce", "nosotros": "conducimos", "vosotros": "conducís", "ellos": "conducen"},
+      "past_simple": {"yo": "conduje", "tú": "condujiste", "vos": "condujiste", "él": "condujo", "nosotros": "condujimos", "vosotros": "condujisteis", "ellos": "condujeron"},
+      "present_perfect": {"yo": "he conducido", "tú": "has conducido", "vos": "has conducido", "él": "ha conducido", "nosotros": "hemos conducido", "vosotros": "habéis conducido", "ellos": "han conducido"},
+      "future_simple": {"yo": "conduciré", "tú": "conducirás", "vos": "conducirás", "él": "conducirá", "nosotros": "conduciremos", "vosotros": "conduciréis", "ellos": "conducirán"},
+      "condicional_simple": {"yo": "conduciría", "tú": "conducirías", "vos": "conducirías", "él": "conduciría", "nosotros": "conduciríamos", "vosotros": "conduciríais", "ellos": "conducirían"},
+      "imperfect_indicative": {"yo": "conducía", "tú": "conducías", "vos": "conducías", "él": "conducía", "nosotros": "conducíamos", "vosotros": "conducíais", "ellos": "conducían"}
     },
     "conjugations_en": {
       "present": {"I": "drive", "you": "drive", "he": "drives", "she": "drives", "it": "drives", "we": "drive", "they": "drive"},
@@ -1999,12 +1999,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "repito", "tú": "repites", "él": "repite", "nosotros": "repetimos", "vosotros": "repetís", "ellos": "repiten"},
-      "past_simple": {"yo": "repetí", "tú": "repetiste", "él": "repitió", "nosotros": "repetimos", "vosotros": "repetisteis", "ellos": "repitieron"},
-      "present_perfect": {"yo": "he repetido", "tú": "has repetido", "él": "ha repetido", "nosotros": "hemos repetido", "vosotros": "habéis repetido", "ellos": "han repetido"},
-      "future_simple": {"yo": "repetiré", "tú": "repetirás", "él": "repetirá", "nosotros": "repetiremos", "vosotros": "repetiréis", "ellos": "repetirán"},
-      "condicional_simple": {"yo": "repetiría", "tú": "repetirías", "él": "repetiría", "nosotros": "repetiríamos", "vosotros": "repetiríais", "ellos": "repetirían"},
-      "imperfect_indicative": {"yo": "repetía", "tú": "repetías", "él": "repetía", "nosotros": "repetíamos", "vosotros": "repetíais", "ellos": "repetían"}
+      "present": {"yo": "repito", "tú": "repites", "vos": "repetís", "él": "repite", "nosotros": "repetimos", "vosotros": "repetís", "ellos": "repiten"},
+      "past_simple": {"yo": "repetí", "tú": "repetiste", "vos": "repetiste", "él": "repitió", "nosotros": "repetimos", "vosotros": "repetisteis", "ellos": "repitieron"},
+      "present_perfect": {"yo": "he repetido", "tú": "has repetido", "vos": "has repetido", "él": "ha repetido", "nosotros": "hemos repetido", "vosotros": "habéis repetido", "ellos": "han repetido"},
+      "future_simple": {"yo": "repetiré", "tú": "repetirás", "vos": "repetirás", "él": "repetirá", "nosotros": "repetiremos", "vosotros": "repetiréis", "ellos": "repetirán"},
+      "condicional_simple": {"yo": "repetiría", "tú": "repetirías", "vos": "repetirías", "él": "repetiría", "nosotros": "repetiríamos", "vosotros": "repetiríais", "ellos": "repetirían"},
+      "imperfect_indicative": {"yo": "repetía", "tú": "repetías", "vos": "repetías", "él": "repetía", "nosotros": "repetíamos", "vosotros": "repetíais", "ellos": "repetían"}
     },
     "conjugations_en": {
       "present": {"I": "repeat", "you": "repeat", "he": "repeats", "she": "repeats", "it": "repeats", "we": "repeat", "they": "repeat"},
@@ -2027,12 +2027,12 @@
       "imperfect_indicative": ["irregular_imperfect", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me voy", "tú": "te vas", "él": "se va", "nosotros": "nos vamos", "vosotros": "os vais", "ellos": "se van"},
-      "past_simple": {"yo": "me fui", "tú": "te fuiste", "él": "se fue", "nosotros": "nos fuimos", "vosotros": "os fuisteis", "ellos": "se fueron"},
-      "present_perfect": {"yo": "me he ido", "tú": "te has ido", "él": "se ha ido", "nosotros": "nos hemos ido", "vosotros": "os habéis ido", "ellos": "se han ido"},
-      "future_simple": {"yo": "me iré", "tú": "te irás", "él": "se irá", "nosotros": "nos iremos", "vosotros": "os iréis", "ellos": "se irán"},
-      "condicional_simple": {"yo": "me iría", "tú": "te irías", "él": "se iría", "nosotros": "nos iríamos", "vosotros": "os iríais", "ellos": "se irían"},
-      "imperfect_indicative": {"yo": "me iba", "tú": "te ibas", "él": "se iba", "nosotros": "nos íbamos", "vosotros": "os ibais", "ellos": "se iban"}
+      "present": {"yo": "me voy", "tú": "te vas", "vos": "te vas", "él": "se va", "nosotros": "nos vamos", "vosotros": "os vais", "ellos": "se van"},
+      "past_simple": {"yo": "me fui", "tú": "te fuiste", "vos": "te fuiste", "él": "se fue", "nosotros": "nos fuimos", "vosotros": "os fuisteis", "ellos": "se fueron"},
+      "present_perfect": {"yo": "me he ido", "tú": "te has ido", "vos": "te has ido", "él": "se ha ido", "nosotros": "nos hemos ido", "vosotros": "os habéis ido", "ellos": "se han ido"},
+      "future_simple": {"yo": "me iré", "tú": "te irás", "vos": "te irás", "él": "se irá", "nosotros": "nos iremos", "vosotros": "os iréis", "ellos": "se irán"},
+      "condicional_simple": {"yo": "me iría", "tú": "te irías", "vos": "te irías", "él": "se iría", "nosotros": "nos iríamos", "vosotros": "os iríais", "ellos": "se irían"},
+      "imperfect_indicative": {"yo": "me iba", "tú": "te ibas", "vos": "te ibas", "él": "se iba", "nosotros": "nos íbamos", "vosotros": "os ibais", "ellos": "se iban"}
     },
     "conjugations_en": {
       "present": {"I": "leave", "you": "leave", "he": "leaves", "she": "leaves", "it": "leaves", "we": "leave", "they": "leave"},
@@ -2055,12 +2055,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me duermo", "tú": "te duermes", "él": "se duerme", "nosotros": "nos dormimos", "vosotros": "os dormís", "ellos": "se duermen"},
-      "past_simple": {"yo": "me dormí", "tú": "te dormiste", "él": "se durmió", "nosotros": "nos dormimos", "vosotros": "os dormisteis", "ellos": "se durmieron"},
-      "present_perfect": {"yo": "me he dormido", "tú": "te has dormido", "él": "se ha dormido", "nosotros": "nos hemos dormido", "vosotros": "os habéis dormido", "ellos": "se han dormido"},
-      "future_simple": {"yo": "me dormiré", "tú": "te dormirás", "él": "se dormirá", "nosotros": "nos dormiremos", "vosotros": "os dormiréis", "ellos": "se dormirán"},
-      "condicional_simple": {"yo": "me dormiría", "tú": "te dormirías", "él": "se dormiría", "nosotros": "nos dormiríamos", "vosotros": "os dormiríais", "ellos": "se dormirían"},
-      "imperfect_indicative": {"yo": "me dormía", "tú": "te dormías", "él": "se dormía", "nosotros": "nos dormíamos", "vosotros": "os dormíais", "ellos": "se dormían"}
+      "present": {"yo": "me duermo", "tú": "te duermes", "vos": "te dormís", "él": "se duerme", "nosotros": "nos dormimos", "vosotros": "os dormís", "ellos": "se duermen"},
+      "past_simple": {"yo": "me dormí", "tú": "te dormiste", "vos": "te dormiste", "él": "se durmió", "nosotros": "nos dormimos", "vosotros": "os dormisteis", "ellos": "se durmieron"},
+      "present_perfect": {"yo": "me he dormido", "tú": "te has dormido", "vos": "te has dormido", "él": "se ha dormido", "nosotros": "nos hemos dormido", "vosotros": "os habéis dormido", "ellos": "se han dormido"},
+      "future_simple": {"yo": "me dormiré", "tú": "te dormirás", "vos": "te dormirás", "él": "se dormirá", "nosotros": "nos dormiremos", "vosotros": "os dormiréis", "ellos": "se dormirán"},
+      "condicional_simple": {"yo": "me dormiría", "tú": "te dormirías", "vos": "te dormirías", "él": "se dormiría", "nosotros": "nos dormiríamos", "vosotros": "os dormiríais", "ellos": "se dormirían"},
+      "imperfect_indicative": {"yo": "me dormía", "tú": "te dormías", "vos": "te dormías", "él": "se dormía", "nosotros": "nos dormíamos", "vosotros": "os dormíais", "ellos": "se dormían"}
     },
     "conjugations_en": {
       "present": {"I": "fall asleep", "you": "fall asleep", "he": "falls asleep", "she": "falls asleep", "it": "falls asleep", "we": "fall asleep", "they": "fall asleep"},
@@ -2083,12 +2083,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me siento", "tú": "te sientes", "él": "se siente", "nosotros": "nos sentimos", "vosotros": "os sentís", "ellos": "se sienten"},
-      "past_simple": {"yo": "me sentí", "tú": "te sentiste", "él": "se sintió", "nosotros": "nos sentimos", "vosotros": "os sentisteis", "ellos": "se sintieron"},
-      "present_perfect": {"yo": "me he sentido", "tú": "te has sentido", "él": "se ha sentido", "nosotros": "nos hemos sentido", "vosotros": "os habéis sentido", "ellos": "se han sentido"},
-      "future_simple": {"yo": "me sentiré", "tú": "te sentirás", "él": "se sentirá", "nosotros": "nos sentiremos", "vosotros": "os sentiréis", "ellos": "se sentirán"},
-      "condicional_simple": {"yo": "me sentiría", "tú": "te sentirías", "él": "se sentiría", "nosotros": "nos sentiríamos", "vosotros": "os sentiríais", "ellos": "se sentirían"},
-      "imperfect_indicative": {"yo": "me sentía", "tú": "te sentías", "él": "se sentía", "nosotros": "nos sentíamos", "vosotros": "os sentíais", "ellos": "se sentían"}
+      "present": {"yo": "me siento", "tú": "te sientes", "vos": "te sentís", "él": "se siente", "nosotros": "nos sentimos", "vosotros": "os sentís", "ellos": "se sienten"},
+      "past_simple": {"yo": "me sentí", "tú": "te sentiste", "vos": "te sentiste", "él": "se sintió", "nosotros": "nos sentimos", "vosotros": "os sentisteis", "ellos": "se sintieron"},
+      "present_perfect": {"yo": "me he sentido", "tú": "te has sentido", "vos": "te has sentido", "él": "se ha sentido", "nosotros": "nos hemos sentido", "vosotros": "os habéis sentido", "ellos": "se han sentido"},
+      "future_simple": {"yo": "me sentiré", "tú": "te sentirás", "vos": "te sentirás", "él": "se sentirá", "nosotros": "nos sentiremos", "vosotros": "os sentiréis", "ellos": "se sentirán"},
+      "condicional_simple": {"yo": "me sentiría", "tú": "te sentirías", "vos": "te sentirías", "él": "se sentiría", "nosotros": "nos sentiríamos", "vosotros": "os sentiríais", "ellos": "se sentirían"},
+      "imperfect_indicative": {"yo": "me sentía", "tú": "te sentías", "vos": "te sentías", "él": "se sentía", "nosotros": "nos sentíamos", "vosotros": "os sentíais", "ellos": "se sentían"}
     },
     "conjugations_en": {
       "present": {"I": "feel", "you": "feel", "he": "feels", "she": "feels", "it": "feels", "we": "feel", "they": "feel"},
@@ -2111,12 +2111,12 @@
       "imperfect_indicative": ["irregular_imperfect", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me veo", "tú": "te ves", "él": "se ve", "nosotros": "nos vemos", "vosotros": "os veis", "ellos": "se ven"},
-      "past_simple": {"yo": "me vi", "tú": "te viste", "él": "se vio", "nosotros": "nos vimos", "vosotros": "os visteis", "ellos": "se vieron"},
-      "present_perfect": {"yo": "me he visto", "tú": "te has visto", "él": "se ha visto", "nosotros": "nos hemos visto", "vosotros": "os habéis visto", "ellos": "se han visto"},
-      "future_simple": {"yo": "me veré", "tú": "te verás", "él": "se verá", "nosotros": "nos veremos", "vosotros": "os veréis", "ellos": "se verán"},
-      "condicional_simple": {"yo": "me vería", "tú": "te verías", "él": "se vería", "nosotros": "nos veríamos", "vosotros": "os veríais", "ellos": "se verían"},
-      "imperfect_indicative": {"yo": "me veía", "tú": "te veías", "él": "se veía", "nosotros": "nos veíamos", "vosotros": "os veíais", "ellos": "se veían"}
+      "present": {"yo": "me veo", "tú": "te ves", "vos": "te ves", "él": "se ve", "nosotros": "nos vemos", "vosotros": "os veis", "ellos": "se ven"},
+      "past_simple": {"yo": "me vi", "tú": "te viste", "vos": "te viste", "él": "se vio", "nosotros": "nos vimos", "vosotros": "os visteis", "ellos": "se vieron"},
+      "present_perfect": {"yo": "me he visto", "tú": "te has visto", "vos": "te has visto", "él": "se ha visto", "nosotros": "nos hemos visto", "vosotros": "os habéis visto", "ellos": "se han visto"},
+      "future_simple": {"yo": "me veré", "tú": "te verás", "vos": "te verás", "él": "se verá", "nosotros": "nos veremos", "vosotros": "os veréis", "ellos": "se verán"},
+      "condicional_simple": {"yo": "me vería", "tú": "te verías", "vos": "te verías", "él": "se vería", "nosotros": "nos veríamos", "vosotros": "os veríais", "ellos": "se verían"},
+      "imperfect_indicative": {"yo": "me veía", "tú": "te veías", "vos": "te veías", "él": "se veía", "nosotros": "nos veíamos", "vosotros": "os veíais", "ellos": "se veían"}
     },
     "conjugations_en": {
       "present": {"I": "see myself", "you": "see yourself", "he": "sees himself", "she": "sees herself", "it": "sees itself", "we": "see ourselves", "they": "see themselves"},
@@ -2139,12 +2139,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me pongo", "tú": "te pones", "él": "se pone", "nosotros": "nos ponemos", "vosotros": "os ponéis", "ellos": "se ponen"},
-      "past_simple": {"yo": "me puse", "tú": "te pusiste", "él": "se puso", "nosotros": "nos pusimos", "vosotros": "os pusisteis", "ellos": "se pusieron"},
-      "present_perfect": {"yo": "me he puesto", "tú": "te has puesto", "él": "se ha puesto", "nosotros": "nos hemos puesto", "vosotros": "os habéis puesto", "ellos": "se han puesto"},
-      "future_simple": {"yo": "me pondré", "tú": "te pondrás", "él": "se pondrá", "nosotros": "nos pondremos", "vosotros": "os pondréis", "ellos": "se pondrán"},
-      "condicional_simple": {"yo": "me pondría", "tú": "te pondrías", "él": "se pondría", "nosotros": "nos pondríamos", "vosotros": "os pondríais", "ellos": "se pondrían"},
-      "imperfect_indicative": {"yo": "me ponía", "tú": "te ponías", "él": "se ponía", "nosotros": "nos poníamos", "vosotros": "os poníais", "ellos": "se ponían"}
+      "present": {"yo": "me pongo", "tú": "te pones", "vos": "te ponés", "él": "se pone", "nosotros": "nos ponemos", "vosotros": "os ponéis", "ellos": "se ponen"},
+      "past_simple": {"yo": "me puse", "tú": "te pusiste", "vos": "te pusiste", "él": "se puso", "nosotros": "nos pusimos", "vosotros": "os pusisteis", "ellos": "se pusieron"},
+      "present_perfect": {"yo": "me he puesto", "tú": "te has puesto", "vos": "te has puesto", "él": "se ha puesto", "nosotros": "nos hemos puesto", "vosotros": "os habéis puesto", "ellos": "se han puesto"},
+      "future_simple": {"yo": "me pondré", "tú": "te pondrás", "vos": "te pondrás", "él": "se pondrá", "nosotros": "nos pondremos", "vosotros": "os pondréis", "ellos": "se pondrán"},
+      "condicional_simple": {"yo": "me pondría", "tú": "te pondrías", "vos": "te pondrías", "él": "se pondría", "nosotros": "nos pondríamos", "vosotros": "os pondríais", "ellos": "se pondrían"},
+      "imperfect_indicative": {"yo": "me ponía", "tú": "te ponías", "vos": "te ponías", "él": "se ponía", "nosotros": "nos poníamos", "vosotros": "os poníais", "ellos": "se ponían"}
     },
     "conjugations_en": {
       "present": {"I": "put on", "you": "put on", "he": "puts on", "she": "puts on", "it": "puts on", "we": "put on", "they": "put on"},
@@ -2167,12 +2167,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me quedo", "tú": "te quedas", "él": "se queda", "nosotros": "nos quedamos", "vosotros": "os quedáis", "ellos": "se quedan"},
-      "past_simple": {"yo": "me quedé", "tú": "te quedaste", "él": "se quedó", "nosotros": "nos quedamos", "vosotros": "os quedasteis", "ellos": "se quedaron"},
-      "present_perfect": {"yo": "me he quedado", "tú": "te has quedado", "él": "se ha quedado", "nosotros": "nos hemos quedado", "vosotros": "os habéis quedado", "ellos": "se han quedado"},
-      "future_simple": {"yo": "me quedaré", "tú": "te quedarás", "él": "se quedará", "nosotros": "nos quedaremos", "vosotros": "os quedaréis", "ellos": "se quedarán"},
-      "condicional_simple": {"yo": "me quedaría", "tú": "te quedarías", "él": "se quedaría", "nosotros": "nos quedaríamos", "vosotros": "os quedaríais", "ellos": "se quedarían"},
-      "imperfect_indicative": {"yo": "me quedaba", "tú": "te quedabas", "él": "se quedaba", "nosotros": "nos quedábamos", "vosotros": "os quedabais", "ellos": "se quedaban"}
+      "present": {"yo": "me quedo", "tú": "te quedas", "vos": "te quedás", "él": "se queda", "nosotros": "nos quedamos", "vosotros": "os quedáis", "ellos": "se quedan"},
+      "past_simple": {"yo": "me quedé", "tú": "te quedaste", "vos": "te quedaste", "él": "se quedó", "nosotros": "nos quedamos", "vosotros": "os quedasteis", "ellos": "se quedaron"},
+      "present_perfect": {"yo": "me he quedado", "tú": "te has quedado", "vos": "te has quedado", "él": "se ha quedado", "nosotros": "nos hemos quedado", "vosotros": "os habéis quedado", "ellos": "se han quedado"},
+      "future_simple": {"yo": "me quedaré", "tú": "te quedarás", "vos": "te quedarás", "él": "se quedará", "nosotros": "nos quedaremos", "vosotros": "os quedaréis", "ellos": "se quedarán"},
+      "condicional_simple": {"yo": "me quedaría", "tú": "te quedarías", "vos": "te quedarías", "él": "se quedaría", "nosotros": "nos quedaríamos", "vosotros": "os quedaríais", "ellos": "se quedarían"},
+      "imperfect_indicative": {"yo": "me quedaba", "tú": "te quedabas", "vos": "te quedabas", "él": "se quedaba", "nosotros": "nos quedábamos", "vosotros": "os quedabais", "ellos": "se quedaban"}
     },
     "conjugations_en": {
       "present": {"I": "stay", "you": "stay", "he": "stays", "she": "stays", "it": "stays", "we": "stay", "they": "stay"},
@@ -2195,12 +2195,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me olvido", "tú": "te olvidas", "él": "se olvida", "nosotros": "nos olvidamos", "vosotros": "os olvidáis", "ellos": "se olvidan"},
-      "past_simple": {"yo": "me olvidé", "tú": "te olvidaste", "él": "se olvidó", "nosotros": "nos olvidamos", "vosotros": "os olvidasteis", "ellos": "se olvidaron"},
-      "present_perfect": {"yo": "me he olvidado", "tú": "te has olvidado", "él": "se ha olvidado", "nosotros": "nos hemos olvidado", "vosotros": "os habéis olvidado", "ellos": "se han olvidado"},
-      "future_simple": {"yo": "me olvidaré", "tú": "te olvidarás", "él": "se olvidará", "nosotros": "nos olvidaremos", "vosotros": "os olvidaréis", "ellos": "se olvidarán"},
-      "condicional_simple": {"yo": "me olvidaría", "tú": "te olvidarías", "él": "se olvidaría", "nosotros": "nos olvidaríamos", "vosotros": "os olvidaríais", "ellos": "se olvidarían"},
-      "imperfect_indicative": {"yo": "me olvidaba", "tú": "te olvidabas", "él": "se olvidaba", "nosotros": "nos olvidábamos", "vosotros": "os olvidabais", "ellos": "se olvidaban"}
+      "present": {"yo": "me olvido", "tú": "te olvidas", "vos": "te olvidás", "él": "se olvida", "nosotros": "nos olvidamos", "vosotros": "os olvidáis", "ellos": "se olvidan"},
+      "past_simple": {"yo": "me olvidé", "tú": "te olvidaste", "vos": "te olvidaste", "él": "se olvidó", "nosotros": "nos olvidamos", "vosotros": "os olvidasteis", "ellos": "se olvidaron"},
+      "present_perfect": {"yo": "me he olvidado", "tú": "te has olvidado", "vos": "te has olvidado", "él": "se ha olvidado", "nosotros": "nos hemos olvidado", "vosotros": "os habéis olvidado", "ellos": "se han olvidado"},
+      "future_simple": {"yo": "me olvidaré", "tú": "te olvidarás", "vos": "te olvidarás", "él": "se olvidará", "nosotros": "nos olvidaremos", "vosotros": "os olvidaréis", "ellos": "se olvidarán"},
+      "condicional_simple": {"yo": "me olvidaría", "tú": "te olvidarías", "vos": "te olvidarías", "él": "se olvidaría", "nosotros": "nos olvidaríamos", "vosotros": "os olvidaríais", "ellos": "se olvidarían"},
+      "imperfect_indicative": {"yo": "me olvidaba", "tú": "te olvidabas", "vos": "te olvidabas", "él": "se olvidaba", "nosotros": "nos olvidábamos", "vosotros": "os olvidabais", "ellos": "se olvidaban"}
     },
     "conjugations_en": {
       "present": {"I": "forget", "you": "forget", "he": "forgets", "she": "forgets", "it": "forgets", "we": "forget", "they": "forget"},
@@ -2223,12 +2223,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me llamo", "tú": "te llamas", "él": "se llama", "nosotros": "nos llamamos", "vosotros": "os llamáis", "ellos": "se llaman"},
-      "past_simple": {"yo": "me llamé", "tú": "te llamaste", "él": "se llamó", "nosotros": "nos llamamos", "vosotros": "os llamasteis", "ellos": "se llamaron"},
-      "present_perfect": {"yo": "me he llamado", "tú": "te has llamado", "él": "se ha llamado", "nosotros": "nos hemos llamado", "vosotros": "os habéis llamado", "ellos": "se han llamado"},
-      "future_simple": {"yo": "me llamaré", "tú": "te llamarás", "él": "se llamará", "nosotros": "nos llamaremos", "vosotros": "os llamaréis", "ellos": "se llamarán"},
-      "condicional_simple": {"yo": "me llamaría", "tú": "te llamarías", "él": "se llamaría", "nosotros": "nos llamaríamos", "vosotros": "os llamaríais", "ellos": "se llamarían"},
-      "imperfect_indicative": {"yo": "me llamaba", "tú": "te llamabas", "él": "se llamaba", "nosotros": "nos llamábamos", "vosotros": "os llamabais", "ellos": "se llamaban"}
+      "present": {"yo": "me llamo", "tú": "te llamas", "vos": "te llamás", "él": "se llama", "nosotros": "nos llamamos", "vosotros": "os llamáis", "ellos": "se llaman"},
+      "past_simple": {"yo": "me llamé", "tú": "te llamaste", "vos": "te llamaste", "él": "se llamó", "nosotros": "nos llamamos", "vosotros": "os llamasteis", "ellos": "se llamaron"},
+      "present_perfect": {"yo": "me he llamado", "tú": "te has llamado", "vos": "te has llamado", "él": "se ha llamado", "nosotros": "nos hemos llamado", "vosotros": "os habéis llamado", "ellos": "se han llamado"},
+      "future_simple": {"yo": "me llamaré", "tú": "te llamarás", "vos": "te llamarás", "él": "se llamará", "nosotros": "nos llamaremos", "vosotros": "os llamaréis", "ellos": "se llamarán"},
+      "condicional_simple": {"yo": "me llamaría", "tú": "te llamarías", "vos": "te llamarías", "él": "se llamaría", "nosotros": "nos llamaríamos", "vosotros": "os llamaríais", "ellos": "se llamarían"},
+      "imperfect_indicative": {"yo": "me llamaba", "tú": "te llamabas", "vos": "te llamabas", "él": "se llamaba", "nosotros": "nos llamábamos", "vosotros": "os llamabais", "ellos": "se llamaban"}
     },
     "conjugations_en": {
       "present": {"I": "am called", "you": "are called", "he": "is called", "she": "is called", "it": "is called", "we": "are called", "they": "are called"},
@@ -2251,12 +2251,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me quito", "tú": "te quitas", "él": "se quita", "nosotros": "nos quitamos", "vosotros": "os quitáis", "ellos": "se quitan"},
-      "past_simple": {"yo": "me quité", "tú": "te quitaste", "él": "se quitó", "nosotros": "nos quitamos", "vosotros": "os quitasteis", "ellos": "se quitaron"},
-      "present_perfect": {"yo": "me he quitado", "tú": "te has quitado", "él": "se ha quitado", "nosotros": "nos hemos quitado", "vosotros": "os habéis quitado", "ellos": "se han quitado"},
-      "future_simple": {"yo": "me quitaré", "tú": "te quitarás", "él": "se quitará", "nosotros": "nos quitaremos", "vosotros": "os quitaréis", "ellos": "se quitarán"},
-      "condicional_simple": {"yo": "me quitaría", "tú": "te quitarías", "él": "se quitaría", "nosotros": "nos quitaríamos", "vosotros": "os quitaríais", "ellos": "se quitarían"},
-      "imperfect_indicative": {"yo": "me quitaba", "tú": "te quitabas", "él": "se quitaba", "nosotros": "nos quitábamos", "vosotros": "os quitabais", "ellos": "se quitaban"}
+      "present": {"yo": "me quito", "tú": "te quitas", "vos": "te quitás", "él": "se quita", "nosotros": "nos quitamos", "vosotros": "os quitáis", "ellos": "se quitan"},
+      "past_simple": {"yo": "me quité", "tú": "te quitaste", "vos": "te quitaste", "él": "se quitó", "nosotros": "nos quitamos", "vosotros": "os quitasteis", "ellos": "se quitaron"},
+      "present_perfect": {"yo": "me he quitado", "tú": "te has quitado", "vos": "te has quitado", "él": "se ha quitado", "nosotros": "nos hemos quitado", "vosotros": "os habéis quitado", "ellos": "se han quitado"},
+      "future_simple": {"yo": "me quitaré", "tú": "te quitarás", "vos": "te quitarás", "él": "se quitará", "nosotros": "nos quitaremos", "vosotros": "os quitaréis", "ellos": "se quitarán"},
+      "condicional_simple": {"yo": "me quitaría", "tú": "te quitarías", "vos": "te quitarías", "él": "se quitaría", "nosotros": "nos quitaríamos", "vosotros": "os quitaríais", "ellos": "se quitarían"},
+      "imperfect_indicative": {"yo": "me quitaba", "tú": "te quitabas", "vos": "te quitabas", "él": "se quitaba", "nosotros": "nos quitábamos", "vosotros": "os quitabais", "ellos": "se quitaban"}
     },
     "conjugations_en": {
       "present": {"I": "take off", "you": "take off", "he": "takes off", "she": "takes off", "it": "takes off", "we": "take off", "they": "take off"},
@@ -2279,12 +2279,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me aburro", "tú": "te aburres", "él": "se aburre", "nosotros": "nos aburrimos", "vosotros": "os aburrís", "ellos": "se aburren"},
-      "past_simple": {"yo": "me aburrí", "tú": "te aburriste", "él": "se aburrió", "nosotros": "nos aburrimos", "vosotros": "os aburristeis", "ellos": "se aburrieron"},
-      "present_perfect": {"yo": "me he aburrido", "tú": "te has aburrido", "él": "se ha aburrido", "nosotros": "nos hemos aburrido", "vosotros": "os habéis aburrido", "ellos": "se han aburrido"},
-      "future_simple": {"yo": "me aburriré", "tú": "te aburrirás", "él": "se aburrirá", "nosotros": "nos aburriremos", "vosotros": "os aburriréis", "ellos": "se aburrirán"},
-      "condicional_simple": {"yo": "me aburriría", "tú": "te aburrirías", "él": "se aburriría", "nosotros": "nos aburriríamos", "vosotros": "os aburriríais", "ellos": "se aburrirían"},
-      "imperfect_indicative": {"yo": "me aburría", "tú": "te aburrías", "él": "se aburría", "nosotros": "nos aburríamos", "vosotros": "os aburríais", "ellos": "se aburrían"}
+      "present": {"yo": "me aburro", "tú": "te aburres", "vos": "te aburrís", "él": "se aburre", "nosotros": "nos aburrimos", "vosotros": "os aburrís", "ellos": "se aburren"},
+      "past_simple": {"yo": "me aburrí", "tú": "te aburriste", "vos": "te aburriste", "él": "se aburrió", "nosotros": "nos aburrimos", "vosotros": "os aburristeis", "ellos": "se aburrieron"},
+      "present_perfect": {"yo": "me he aburrido", "tú": "te has aburrido", "vos": "te has aburrido", "él": "se ha aburrido", "nosotros": "nos hemos aburrido", "vosotros": "os habéis aburrido", "ellos": "se han aburrido"},
+      "future_simple": {"yo": "me aburriré", "tú": "te aburrirás", "vos": "te aburrirás", "él": "se aburrirá", "nosotros": "nos aburriremos", "vosotros": "os aburriréis", "ellos": "se aburrirán"},
+      "condicional_simple": {"yo": "me aburriría", "tú": "te aburrirías", "vos": "te aburrirías", "él": "se aburriría", "nosotros": "nos aburriríamos", "vosotros": "os aburriríais", "ellos": "se aburrirían"},
+      "imperfect_indicative": {"yo": "me aburría", "tú": "te aburrías", "vos": "te aburrías", "él": "se aburría", "nosotros": "nos aburríamos", "vosotros": "os aburríais", "ellos": "se aburrían"}
     },
     "conjugations_en": {
       "present": {"I": "get bored", "you": "get bored", "he": "gets bored", "she": "gets bored", "it": "gets bored", "we": "get bored", "they": "get bored"},
@@ -2307,12 +2307,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "quepo", "tú": "cabes", "él": "cabe", "nosotros": "cabemos", "vosotros": "cabéis", "ellos": "caben"},
-      "past_simple": {"yo": "cupe", "tú": "cupiste", "él": "cupo", "nosotros": "cupimos", "vosotros": "cupisteis", "ellos": "cupieron"},
-      "present_perfect": {"yo": "he cabido", "tú": "has cabido", "él": "ha cabido", "nosotros": "hemos cabido", "vosotros": "habéis cabido", "ellos": "han cabido"},
-      "future_simple": {"yo": "cabré", "tú": "cabrás", "él": "cabrá", "nosotros": "cabremos", "vosotros": "cabréis", "ellos": "cabrán"},
-      "condicional_simple": {"yo": "cabría", "tú": "cabrías", "él": "cabría", "nosotros": "cabríamos", "vosotros": "cabríais", "ellos": "cabrían"},
-      "imperfect_indicative": {"yo": "cabía", "tú": "cabías", "él": "cabía", "nosotros": "cabíamos", "vosotros": "cabíais", "ellos": "cabían"}
+      "present": {"yo": "quepo", "tú": "cabes", "vos": "cabés", "él": "cabe", "nosotros": "cabemos", "vosotros": "cabéis", "ellos": "caben"},
+      "past_simple": {"yo": "cupe", "tú": "cupiste", "vos": "cupiste", "él": "cupo", "nosotros": "cupimos", "vosotros": "cupisteis", "ellos": "cupieron"},
+      "present_perfect": {"yo": "he cabido", "tú": "has cabido", "vos": "has cabido", "él": "ha cabido", "nosotros": "hemos cabido", "vosotros": "habéis cabido", "ellos": "han cabido"},
+      "future_simple": {"yo": "cabré", "tú": "cabrás", "vos": "cabrás", "él": "cabrá", "nosotros": "cabremos", "vosotros": "cabréis", "ellos": "cabrán"},
+      "condicional_simple": {"yo": "cabría", "tú": "cabrías", "vos": "cabrías", "él": "cabría", "nosotros": "cabríamos", "vosotros": "cabríais", "ellos": "cabrían"},
+      "imperfect_indicative": {"yo": "cabía", "tú": "cabías", "vos": "cabías", "él": "cabía", "nosotros": "cabíamos", "vosotros": "cabíais", "ellos": "cabían"}
     },
     "conjugations_en": {
       "present": {"I": "fit", "you": "fit", "he": "fits", "she": "fits", "it": "fits", "we": "fit", "they": "fit"},
@@ -2335,12 +2335,12 @@
       "imperfect_indicative": ["regular"]
     },
     "conjugations": {
-      "present": {"yo": "valgo", "tú": "vales", "él": "vale", "nosotros": "valemos", "vosotros": "valéis", "ellos": "valen"},
-      "past_simple": {"yo": "valí", "tú": "valiste", "él": "valió", "nosotros": "valimos", "vosotros": "valisteis", "ellos": "valieron"},
-      "present_perfect": {"yo": "he valido", "tú": "has valido", "él": "ha valido", "nosotros": "hemos valido", "vosotros": "habéis valido", "ellos": "han valido"},
-      "future_simple": {"yo": "valdré", "tú": "valdrás", "él": "valdrá", "nosotros": "valdremos", "vosotros": "valdréis", "ellos": "valdrán"},
-      "condicional_simple": {"yo": "valdría", "tú": "valdrías", "él": "valdría", "nosotros": "valdríamos", "vosotros": "valdríais", "ellos": "valdrían"},
-      "imperfect_indicative": {"yo": "valía", "tú": "valías", "él": "valía", "nosotros": "valíamos", "vosotros": "valíais", "ellos": "valían"}
+      "present": {"yo": "valgo", "tú": "vales", "vos": "valés", "él": "vale", "nosotros": "valemos", "vosotros": "valéis", "ellos": "valen"},
+      "past_simple": {"yo": "valí", "tú": "valiste", "vos": "valiste", "él": "valió", "nosotros": "valimos", "vosotros": "valisteis", "ellos": "valieron"},
+      "present_perfect": {"yo": "he valido", "tú": "has valido", "vos": "has valido", "él": "ha valido", "nosotros": "hemos valido", "vosotros": "habéis valido", "ellos": "han valido"},
+      "future_simple": {"yo": "valdré", "tú": "valdrás", "vos": "valdrás", "él": "valdrá", "nosotros": "valdremos", "vosotros": "valdréis", "ellos": "valdrán"},
+      "condicional_simple": {"yo": "valdría", "tú": "valdrías", "vos": "valdrías", "él": "valdría", "nosotros": "valdríamos", "vosotros": "valdríais", "ellos": "valdrían"},
+      "imperfect_indicative": {"yo": "valía", "tú": "valías", "vos": "valías", "él": "valía", "nosotros": "valíamos", "vosotros": "valíais", "ellos": "valían"}
     },
     "conjugations_en": {
       "present": {"I": "am worth", "you": "are worth", "he": "is worth", "she": "is worth", "it": "is worth", "we": "are worth", "they": "are worth"},
@@ -2363,12 +2363,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me divierto", "tú": "te diviertes", "él": "se divierte", "nosotros": "nos divertimos", "vosotros": "os divertís", "ellos": "se divierten"},
-      "past_simple": {"yo": "me divertí", "tú": "te divertiste", "él": "se divirtió", "nosotros": "nos divertimos", "vosotros": "os divertisteis", "ellos": "se divirtieron"},
-      "present_perfect": {"yo": "me he divertido", "tú": "te has divertido", "él": "se ha divertido", "nosotros": "nos hemos divertido", "vosotros": "os habéis divertido", "ellos": "se han divertido"},
-      "future_simple": {"yo": "me divertiré", "tú": "te divertirás", "él": "se divertirá", "nosotros": "nos divertiremos", "vosotros": "os divertiréis", "ellos": "se divertirán"},
-      "condicional_simple": {"yo": "me divertiría", "tú": "te divertirías", "él": "se divertiría", "nosotros": "nos divertiríamos", "vosotros": "os divertiríais", "ellos": "se divertirían"},
-      "imperfect_indicative": {"yo": "me divertía", "tú": "te divertías", "él": "se divertía", "nosotros": "nos divertíamos", "vosotros": "os divertíais", "ellos": "se divertían"}
+      "present": {"yo": "me divierto", "tú": "te diviertes", "vos": "te divertís", "él": "se divierte", "nosotros": "nos divertimos", "vosotros": "os divertís", "ellos": "se divierten"},
+      "past_simple": {"yo": "me divertí", "tú": "te divertiste", "vos": "te divertiste", "él": "se divirtió", "nosotros": "nos divertimos", "vosotros": "os divertisteis", "ellos": "se divirtieron"},
+      "present_perfect": {"yo": "me he divertido", "tú": "te has divertido", "vos": "te has divertido", "él": "se ha divertido", "nosotros": "nos hemos divertido", "vosotros": "os habéis divertido", "ellos": "se han divertido"},
+      "future_simple": {"yo": "me divertiré", "tú": "te divertirás", "vos": "te divertirás", "él": "se divertirá", "nosotros": "nos divertiremos", "vosotros": "os divertiréis", "ellos": "se divertirán"},
+      "condicional_simple": {"yo": "me divertiría", "tú": "te divertirías", "vos": "te divertirías", "él": "se divertiría", "nosotros": "nos divertiríamos", "vosotros": "os divertiríais", "ellos": "se divertirían"},
+      "imperfect_indicative": {"yo": "me divertía", "tú": "te divertías", "vos": "te divertías", "él": "se divertía", "nosotros": "nos divertíamos", "vosotros": "os divertíais", "ellos": "se divertían"}
     },
     "conjugations_en": {
       "present": {"I": "have fun", "you": "have fun", "he": "has fun", "she": "has fun", "it": "has fun", "we": "have fun", "they": "have fun"},
@@ -2391,12 +2391,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me arrepiento", "tú": "te arrepientes", "él": "se arrepiente", "nosotros": "nos arrepentimos", "vosotros": "os arrepentís", "ellos": "se arrepienten"},
-      "past_simple": {"yo": "me arrepentí", "tú": "te arrepentiste", "él": "se arrepintió", "nosotros": "nos arrepentimos", "vosotros": "os arrepentisteis", "ellos": "se arrepintieron"},
-      "present_perfect": {"yo": "me he arrepentido", "tú": "te has arrepentido", "él": "se ha arrepentido", "nosotros": "nos hemos arrepentido", "vosotros": "os habéis arrepentido", "ellos": "se han arrepentido"},
-      "future_simple": {"yo": "me arrepentiré", "tú": "te arrepentirás", "él": "se arrepentirá", "nosotros": "nos arrepentiremos", "vosotros": "os arrepentiréis", "ellos": "se arrepentirán"},
-      "condicional_simple": {"yo": "me arrepentiría", "tú": "te arrepentirías", "él": "se arrepentiría", "nosotros": "nos arrepentiríamos", "vosotros": "os arrepentiríais", "ellos": "se arrepentirían"},
-      "imperfect_indicative": {"yo": "me arrepentía", "tú": "te arrepentías", "él": "se arrepentía", "nosotros": "nos arrepentíamos", "vosotros": "os arrepentíais", "ellos": "se arrepentían"}
+      "present": {"yo": "me arrepiento", "tú": "te arrepientes", "vos": "te arrepentís", "él": "se arrepiente", "nosotros": "nos arrepentimos", "vosotros": "os arrepentís", "ellos": "se arrepienten"},
+      "past_simple": {"yo": "me arrepentí", "tú": "te arrepentiste", "vos": "te arrepentiste", "él": "se arrepintió", "nosotros": "nos arrepentimos", "vosotros": "os arrepentisteis", "ellos": "se arrepintieron"},
+      "present_perfect": {"yo": "me he arrepentido", "tú": "te has arrepentido", "vos": "te has arrepentido", "él": "se ha arrepentido", "nosotros": "nos hemos arrepentido", "vosotros": "os habéis arrepentido", "ellos": "se han arrepentido"},
+      "future_simple": {"yo": "me arrepentiré", "tú": "te arrepentirás", "vos": "te arrepentirás", "él": "se arrepentirá", "nosotros": "nos arrepentiremos", "vosotros": "os arrepentiréis", "ellos": "se arrepentirán"},
+      "condicional_simple": {"yo": "me arrepentiría", "tú": "te arrepentirías", "vos": "te arrepentirías", "él": "se arrepentiría", "nosotros": "nos arrepentiríamos", "vosotros": "os arrepentiríais", "ellos": "se arrepentirían"},
+      "imperfect_indicative": {"yo": "me arrepentía", "tú": "te arrepentías", "vos": "te arrepentías", "él": "se arrepentía", "nosotros": "nos arrepentíamos", "vosotros": "os arrepentíais", "ellos": "se arrepentían"}
     },
     "conjugations_en": {
       "present": {"I": "regret", "you": "regret", "he": "regrets", "she": "regrets", "it": "regrets", "we": "regret", "they": "regret"},
@@ -2419,12 +2419,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me río", "tú": "te ríes", "él": "se ríe", "nosotros": "nos reímos", "vosotros": "os reís", "ellos": "se ríen"},
-      "past_simple": {"yo": "me reí", "tú": "te reíste", "él": "se rió", "nosotros": "nos reímos", "vosotros": "os reísteis", "ellos": "se rieron"},
-      "present_perfect": {"yo": "me he reído", "tú": "te has reído", "él": "se ha reído", "nosotros": "nos hemos reído", "vosotros": "os habéis reído", "ellos": "se han reído"},
-      "future_simple": {"yo": "me reiré", "tú": "te reirás", "él": "se reirá", "nosotros": "nos reiremos", "vosotros": "os reiréis", "ellos": "se reirán"},
-      "condicional_simple": {"yo": "me reiría", "tú": "te reirías", "él": "se reiría", "nosotros": "nos reiríamos", "vosotros": "os reiríais", "ellos": "se reirían"},
-      "imperfect_indicative": {"yo": "me reía", "tú": "te reías", "él": "se reía", "nosotros": "nos reíamos", "vosotros": "os reíais", "ellos": "se reían"}
+      "present": {"yo": "me río", "tú": "te ríes", "vos": "te reís", "él": "se ríe", "nosotros": "nos reímos", "vosotros": "os reís", "ellos": "se ríen"},
+      "past_simple": {"yo": "me reí", "tú": "te reíste", "vos": "te reíste", "él": "se rió", "nosotros": "nos reímos", "vosotros": "os reísteis", "ellos": "se rieron"},
+      "present_perfect": {"yo": "me he reído", "tú": "te has reído", "vos": "te has reído", "él": "se ha reído", "nosotros": "nos hemos reído", "vosotros": "os habéis reído", "ellos": "se han reído"},
+      "future_simple": {"yo": "me reiré", "tú": "te reirás", "vos": "te reirás", "él": "se reirá", "nosotros": "nos reiremos", "vosotros": "os reiréis", "ellos": "se reirán"},
+      "condicional_simple": {"yo": "me reiría", "tú": "te reirías", "vos": "te reirías", "él": "se reiría", "nosotros": "nos reiríamos", "vosotros": "os reiríais", "ellos": "se reirían"},
+      "imperfect_indicative": {"yo": "me reía", "tú": "te reías", "vos": "te reías", "él": "se reía", "nosotros": "nos reíamos", "vosotros": "os reíais", "ellos": "se reían"}
     },
     "conjugations_en": {
       "present": {"I": "laugh", "you": "laugh", "he": "laughs", "she": "laughs", "it": "laughs", "we": "laugh", "they": "laugh"},
@@ -2447,12 +2447,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me convierto", "tú": "te conviertes", "él": "se convierte", "nosotros": "nos convertimos", "vosotros": "os convertís", "ellos": "se convierten"},
-      "past_simple": {"yo": "me convertí", "tú": "te convertiste", "él": "se convirtió", "nosotros": "nos convertimos", "vosotros": "os convertisteis", "ellos": "se convirtieron"},
-      "present_perfect": {"yo": "me he convertido", "tú": "te has convertido", "él": "se ha convertido", "nosotros": "nos hemos convertido", "vosotros": "os habéis convertido", "ellos": "se han convertido"},
-      "future_simple": {"yo": "me convertiré", "tú": "te convertirás", "él": "se convertirá", "nosotros": "nos convertiremos", "vosotros": "os convertiréis", "ellos": "se convertirán"},
-      "condicional_simple": {"yo": "me convertiría", "tú": "te convertirías", "él": "se convertiría", "nosotros": "nos convertiríamos", "vosotros": "os convertiríais", "ellos": "se convertirían"},
-      "imperfect_indicative": {"yo": "me convertía", "tú": "te convertías", "él": "se convertía", "nosotros": "nos convertíamos", "vosotros": "os convertíais", "ellos": "se convertían"}
+      "present": {"yo": "me convierto", "tú": "te conviertes", "vos": "te convertís", "él": "se convierte", "nosotros": "nos convertimos", "vosotros": "os convertís", "ellos": "se convierten"},
+      "past_simple": {"yo": "me convertí", "tú": "te convertiste", "vos": "te convertiste", "él": "se convirtió", "nosotros": "nos convertimos", "vosotros": "os convertisteis", "ellos": "se convirtieron"},
+      "present_perfect": {"yo": "me he convertido", "tú": "te has convertido", "vos": "te has convertido", "él": "se ha convertido", "nosotros": "nos hemos convertido", "vosotros": "os habéis convertido", "ellos": "se han convertido"},
+      "future_simple": {"yo": "me convertiré", "tú": "te convertirás", "vos": "te convertirás", "él": "se convertirá", "nosotros": "nos convertiremos", "vosotros": "os convertiréis", "ellos": "se convertirán"},
+      "condicional_simple": {"yo": "me convertiría", "tú": "te convertirías", "vos": "te convertirías", "él": "se convertiría", "nosotros": "nos convertiríamos", "vosotros": "os convertiríais", "ellos": "se convertirían"},
+      "imperfect_indicative": {"yo": "me convertía", "tú": "te convertías", "vos": "te convertías", "él": "se convertía", "nosotros": "nos convertíamos", "vosotros": "os convertíais", "ellos": "se convertían"}
     },
     "conjugations_en": {
       "present": {"I": "become", "you": "become", "he": "becomes", "she": "becomes", "it": "becomes", "we": "become", "they": "become"},
@@ -2475,12 +2475,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me acerco", "tú": "te acercas", "él": "se acerca", "nosotros": "nos acercamos", "vosotros": "os acercáis", "ellos": "se acercan"},
-      "past_simple": {"yo": "me acerqué", "tú": "te acercaste", "él": "se acercó", "nosotros": "nos acercamos", "vosotros": "os acercasteis", "ellos": "se acercaron"},
-      "present_perfect": {"yo": "me he acercado", "tú": "te has acercado", "él": "se ha acercado", "nosotros": "nos hemos acercado", "vosotros": "os habéis acercado", "ellos": "se han acercado"},
-      "future_simple": {"yo": "me acercaré", "tú": "te acercarás", "él": "se acercará", "nosotros": "nos acercaremos", "vosotros": "os acercaréis", "ellos": "se acercarán"},
-      "condicional_simple": {"yo": "me acercaría", "tú": "te acercarías", "él": "se acercaría", "nosotros": "nos acercaríamos", "vosotros": "os acercaríais", "ellos": "se acercarían"},
-      "imperfect_indicative": {"yo": "me acercaba", "tú": "te acercabas", "él": "se acercaba", "nosotros": "nos acercábamos", "vosotros": "os acercabais", "ellos": "se acercaban"}
+      "present": {"yo": "me acerco", "tú": "te acercas", "vos": "te acercás", "él": "se acerca", "nosotros": "nos acercamos", "vosotros": "os acercáis", "ellos": "se acercan"},
+      "past_simple": {"yo": "me acerqué", "tú": "te acercaste", "vos": "te acercaste", "él": "se acercó", "nosotros": "nos acercamos", "vosotros": "os acercasteis", "ellos": "se acercaron"},
+      "present_perfect": {"yo": "me he acercado", "tú": "te has acercado", "vos": "te has acercado", "él": "se ha acercado", "nosotros": "nos hemos acercado", "vosotros": "os habéis acercado", "ellos": "se han acercado"},
+      "future_simple": {"yo": "me acercaré", "tú": "te acercarás", "vos": "te acercarás", "él": "se acercará", "nosotros": "nos acercaremos", "vosotros": "os acercaréis", "ellos": "se acercarán"},
+      "condicional_simple": {"yo": "me acercaría", "tú": "te acercarías", "vos": "te acercarías", "él": "se acercaría", "nosotros": "nos acercaríamos", "vosotros": "os acercaríais", "ellos": "se acercarían"},
+      "imperfect_indicative": {"yo": "me acercaba", "tú": "te acercabas", "vos": "te acercabas", "él": "se acercaba", "nosotros": "nos acercábamos", "vosotros": "os acercabais", "ellos": "se acercaban"}
     },
     "conjugations_en": {
       "present": {"I": "approach", "you": "approach", "he": "approaches", "she": "approaches", "it": "approaches", "we": "approach", "they": "approach"},
@@ -2503,12 +2503,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me alejo", "tú": "te alejas", "él": "se aleja", "nosotros": "nos alejamos", "vosotros": "os alejáis", "ellos": "se alejan"},
-      "past_simple": {"yo": "me alejé", "tú": "te alejaste", "él": "se alejó", "nosotros": "nos alejamos", "vosotros": "os alejasteis", "ellos": "se alejaron"},
-      "present_perfect": {"yo": "me he alejado", "tú": "te has alejado", "él": "se ha alejado", "nosotros": "nos hemos alejado", "vosotros": "os habéis alejado", "ellos": "se han alejado"},
-      "future_simple": {"yo": "me alejaré", "tú": "te alejarás", "él": "se alejará", "nosotros": "nos alejaremos", "vosotros": "os alejaréis", "ellos": "se alejarán"},
-      "condicional_simple": {"yo": "me alejaría", "tú": "te alejarías", "él": "se alejaría", "nosotros": "nos alejaríamos", "vosotros": "os alejaríais", "ellos": "se alejarían"},
-      "imperfect_indicative": {"yo": "me alejaba", "tú": "te alejabas", "él": "se alejaba", "nosotros": "nos alejábamos", "vosotros": "os alejabais", "ellos": "se alejaban"}
+      "present": {"yo": "me alejo", "tú": "te alejas", "vos": "te alejás", "él": "se aleja", "nosotros": "nos alejamos", "vosotros": "os alejáis", "ellos": "se alejan"},
+      "past_simple": {"yo": "me alejé", "tú": "te alejaste", "vos": "te alejaste", "él": "se alejó", "nosotros": "nos alejamos", "vosotros": "os alejasteis", "ellos": "se alejaron"},
+      "present_perfect": {"yo": "me he alejado", "tú": "te has alejado", "vos": "te has alejado", "él": "se ha alejado", "nosotros": "nos hemos alejado", "vosotros": "os habéis alejado", "ellos": "se han alejado"},
+      "future_simple": {"yo": "me alejaré", "tú": "te alejarás", "vos": "te alejarás", "él": "se alejará", "nosotros": "nos alejaremos", "vosotros": "os alejaréis", "ellos": "se alejarán"},
+      "condicional_simple": {"yo": "me alejaría", "tú": "te alejarías", "vos": "te alejarías", "él": "se alejaría", "nosotros": "nos alejaríamos", "vosotros": "os alejaríais", "ellos": "se alejarían"},
+      "imperfect_indicative": {"yo": "me alejaba", "tú": "te alejabas", "vos": "te alejabas", "él": "se alejaba", "nosotros": "nos alejábamos", "vosotros": "os alejabais", "ellos": "se alejaban"}
     },
     "conjugations_en": {
       "present": {"I": "move away", "you": "move away", "he": "moves away", "she": "moves away", "it": "moves away", "we": "move away", "they": "move away"},
@@ -2531,12 +2531,12 @@
       "imperfect_indicative": ["regular", "reflexive"]
     },
     "conjugations": {
-      "present": {"yo": "me enfermo", "tú": "te enfermas", "él": "se enferma", "nosotros": "nos enfermamos", "vosotros": "os enfermáis", "ellos": "se enferman"},
-      "past_simple": {"yo": "me enfermé", "tú": "te enfermaste", "él": "se enfermó", "nosotros": "nos enfermamos", "vosotros": "os enfermasteis", "ellos": "se enfermaron"},
-      "present_perfect": {"yo": "me he enfermado", "tú": "te has enfermado", "él": "se ha enfermado", "nosotros": "nos hemos enfermado", "vosotros": "os habéis enfermado", "ellos": "se han enfermado"},
-      "future_simple": {"yo": "me enfermaré", "tú": "te enfermarás", "él": "se enfermará", "nosotros": "nos enfermaremos", "vosotros": "os enfermaréis", "ellos": "se enfermarán"},
-      "condicional_simple": {"yo": "me enfermaría", "tú": "te enfermarías", "él": "se enfermaría", "nosotros": "nos enfermaríamos", "vosotros": "os enfermaríais", "ellos": "se enfermarían"},
-      "imperfect_indicative": {"yo": "me enfermaba", "tú": "te enfermabas", "él": "se enfermaba", "nosotros": "nos enfermábamos", "vosotros": "os enfermabais", "ellos": "se enfermaban"}
+      "present": {"yo": "me enfermo", "tú": "te enfermas", "vos": "te enfermás", "él": "se enferma", "nosotros": "nos enfermamos", "vosotros": "os enfermáis", "ellos": "se enferman"},
+      "past_simple": {"yo": "me enfermé", "tú": "te enfermaste", "vos": "te enfermaste", "él": "se enfermó", "nosotros": "nos enfermamos", "vosotros": "os enfermasteis", "ellos": "se enfermaron"},
+      "present_perfect": {"yo": "me he enfermado", "tú": "te has enfermado", "vos": "te has enfermado", "él": "se ha enfermado", "nosotros": "nos hemos enfermado", "vosotros": "os habéis enfermado", "ellos": "se han enfermado"},
+      "future_simple": {"yo": "me enfermaré", "tú": "te enfermarás", "vos": "te enfermarás", "él": "se enfermará", "nosotros": "nos enfermaremos", "vosotros": "os enfermaréis", "ellos": "se enfermarán"},
+      "condicional_simple": {"yo": "me enfermaría", "tú": "te enfermarías", "vos": "te enfermarías", "él": "se enfermaría", "nosotros": "nos enfermaríamos", "vosotros": "os enfermaríais", "ellos": "se enfermarían"},
+      "imperfect_indicative": {"yo": "me enfermaba", "tú": "te enfermabas", "vos": "te enfermabas", "él": "se enfermaba", "nosotros": "nos enfermábamos", "vosotros": "os enfermabais", "ellos": "se enfermaban"}
     },
     "conjugations_en": {
       "present": {"I": "get sick", "you": "get sick", "he": "gets sick", "she": "gets sick", "it": "gets sick", "we": "get sick", "they": "get sick"},


### PR DESCRIPTION
## Summary
- extend pronoun lists to include **vos**
- show a button for `vos` not selected by default
- random bubble messages handle any number of pronouns
- add Spanish **vos** forms for every verb

## Testing
- `node -c script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854c815a2248327994505fa59713a58