### PR TITLE
Fix deploy workflow by inlining Supabase config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,10 @@ jobs:
 
         uses: actions/checkout@v3
 
-      - name: Create Supabase Config File ⚙️
+      - name: Inject Supabase Credentials 🔑
         run: |
-          echo "const SUPABASE_URL = '${{ secrets.SUPABASE_URL }}';" > config.js
-          echo "const SUPABASE_ANON_KEY = '${{ secrets.SUPABASE_ANON_KEY }}';" >> config.js
+          sed -i 's|%%SUPABASE_URL%%|${{ secrets.SUPABASE_URL }}|g' index.html
+          sed -i 's|%%SUPABASE_ANON_KEY%%|${{ secrets.SUPABASE_ANON_KEY }}|g' index.html
 
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-config.js

--- a/index.html
+++ b/index.html
@@ -286,13 +286,16 @@
       <a class="coffee-link" id="coffee-link" href="https://buymeacoffee.com/theconjugator" target="_blank" rel="noopener">Support the Game!</a>
 
   </div>
-  <div id="left-bubbles"></div>
-  <div id="right-bubbles"></div>
-  
+    <div id="left-bubbles"></div>
+    <div id="right-bubbles"></div>
 
-  <script src="config.js"></script>
-  <script src="tooltips.js" defer></script>
-  <script src="script.js" defer></script>
+    <script>
+      // These placeholders will be replaced by the GitHub Actions workflow
+      const SUPABASE_URL = "%%SUPABASE_URL%%";
+      const SUPABASE_ANON_KEY = "%%SUPABASE_ANON_KEY%%";
+    </script>
+    <script src="tooltips.js" defer></script>
+    <script src="script.js" defer></script>
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", () => {


### PR DESCRIPTION
## Summary
- inline Supabase credentials in `index.html`
- update GitHub Actions workflow to replace credentials during deploy
- remove `config.js` from `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685524f5c27083278acf68d70c82bab5