### PR TITLE
Set Supabase credentials for local use

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,9 +324,8 @@
     <div id="right-bubbles"></div>
 
     <script>
-      // These placeholders will be replaced by the GitHub Actions workflow
-      const SUPABASE_URL = "%%SUPABASE_URL%%";
-      const SUPABASE_ANON_KEY = "%%SUPABASE_ANON_KEY%%";
+      const SUPABASE_URL = "https://dmaztdtlixwcnwcgwsnp.supabase.co";
+      const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRtYXp0ZHRsaXh3Y253Y2d3c25wIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAzOTE3OTEsImV4cCI6MjA2NTk2Nzc5MX0.F-jBVWM9usSxXQPd-5JDeZUPg6JcOh-FY8tbFXSgGDo";
     </script>
     <script src="tooltips.js" defer></script>
     <script src="script.js" defer></script>


### PR DESCRIPTION
## Summary
- hardcode Supabase credentials in index.html so `script.js` can initialize the client

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68567599b74083278d5acfbecbf079b2