### PR TITLE
Style Options button for parity

### DIFF
--- a/style.css
+++ b/style.css
@@ -1428,6 +1428,7 @@ button:active {
 }
 /* Splash buttons */
 #initial-start-button,
+#settings-button,
 #help-button {
   font-family: var(--font-pixel);
   font-size: 1.5em;
@@ -1441,8 +1442,10 @@ button:active {
 }
 
 #initial-start-button:hover,
+#settings-button:hover,
 #help-button:hover,
 #initial-start-button.selected,
+#settings-button.selected,
 #help-button.selected {
   animation: splash-blink 1s infinite;
   color: #ffffff !important;


### PR DESCRIPTION
## Summary
- style the Options button like the Start Game button
- make it blink when selected

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685675c21ed4832781245afbe46a9c22