### PR TITLE
Update options labels and defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,15 +57,9 @@
 
       <fieldset>
         <legend>Visuals</legend>
-        <label><input type="checkbox" id="toggle-animations-setting"> Enable Animations</label>
+        <label><input type="checkbox" id="toggle-animations-setting"> Enable Bubbles Animation</label>
         <label><input type="checkbox" id="toggle-chuache-reactions-setting"> Enable Character Reactions</label>
       </fieldset>
-
-      <fieldset>
-        <legend>Gameplay Defaults</legend>
-        <label><input type="checkbox" id="default-enable-vos-setting"> Enable 'vos' Pronoun by Default</label>
-      </fieldset>
-
       <fieldset>
           <legend>Miscellaneous</legend>
           <button id="reset-settings-button">Reset All Settings</button>

--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ menuMusic.loop = true;
 gameMusic.loop = true;
 
 // Global settings defaults
-window.animationsEnabled = true;
+window.animationsEnabled = false;
 window.chuacheReactionsEnabled = true;
 window.defaultVosEnabled = false;
 
@@ -34,7 +34,7 @@ function loadSettings() {
   const chuache = localStorage.getItem('chuacheReactionsEnabled');
   const vos = localStorage.getItem('defaultVosEnabled');
 
-  window.animationsEnabled = anim !== null ? anim === 'true' : true;
+  window.animationsEnabled = anim !== null ? anim === 'true' : false;
   window.chuacheReactionsEnabled = chuache !== null ? chuache === 'true' : true;
   window.defaultVosEnabled = vos === 'true';
 


### PR DESCRIPTION
## Summary
- rename **Enable Animations** option to **Enable Bubbles Animation**
- remove the *vos* default option from the settings panel
- disable bubble animations by default

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6858f3e654c48327941b0d9cfb5bda7c