### PR TITLE
Add back button to mode selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -922,7 +922,14 @@ function navigateToStep(stepName) {
             else configFlowScreenDiv.classList.remove('splash-active');
         }
         if (infoPanel) infoPanel.style.display = stepName === 'splash' ? 'none' : 'block';
-        if (backButton) backButton.style.display = 'none';
+        if (backButton) {
+            if (stepName === 'splash') {
+                backButton.style.display = 'none';
+            } else {
+                backButton.style.display = 'block';
+                if (confirmModeButton) confirmModeButton.insertAdjacentElement('afterend', backButton);
+            }
+        }
 
         if (stepName === 'splash') {
             if (initialStartButton) initialStartButton.disabled = false;


### PR DESCRIPTION
## Summary
- show back button on the mode selection screen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6858f4171e748327a933473b3f9e08a7