### PR TITLE
Remove timer cap

### DIFF
--- a/script.js
+++ b/script.js
@@ -2573,8 +2573,8 @@ function checkAnswer() {
 	else if (streak <= 8)  timeBonus = 8;
 	else if (streak <= 10) timeBonus = 9;
 	else                   timeBonus = 10;
-	// opcional: máximo 240 s
-        timerTimeLeft = Math.min(240, timerTimeLeft + timeBonus);
+        // add time without an upper limit
+        timerTimeLeft += timeBonus;
         checkTickingSound();
         showTimeChange(timeBonus);
 

--- a/tooltips.js
+++ b/tooltips.js
@@ -10,7 +10,7 @@ const specificInfoData = {
     html: `You have <strong>4 minutes</strong> to score as many points as possible.<br>
            <strong class="modal-subtitle">Time Mechanics:</strong><br>
            - Start with 4:00 minutes.<br>
-           - Correct answers ✅ add time based on your streak (<span class="emphasis-mechanic">+5s to +10s</span>). Max time is 4:00.<br>
+           - Correct answers ✅ add time based on your streak (<span class="emphasis-mechanic">+5s to +10s</span>). No upper time limit.<br>
            - Incorrect/Skipped answers ❌ deduct <span class="emphasis-mechanic">3 seconds</span>.<br><br>
            <strong class="modal-subtitle">Time UI:</strong><br>
            - ⏳ Remaining Time: Main clock (turns <span class="text-red">red</span> and pulses in the last 10s).<br>


### PR DESCRIPTION
## Summary
- drop the 4 minute cap on timer mode
- update tooltip description to mention unlimited clock growth

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68629d2ba228832795c765909c48cb78