### PR TITLE
Improve Hall of Fame overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,21 +217,7 @@
     </div>
   </div>
 
-  <div id="setup-records" style="margin-top:20px; display:none;">
-    <h3>🏆 Los mejores de los mejores / Best of the Best 🏆</h3>
-    <div class="mode-records" data-mode="infinite">
-      <h4>♾️InFiNiTeRs♾️</h4>
-      <ul class="record-list"></ul>
-    </div>
-    <div class="mode-records" data-mode="timer">
-      <h4>⏱DesPaCiToS⏱️</h4>
-      <ul class="record-list"></ul>
-    </div>
-    <div class="mode-records" data-mode="lives">
-      <h4>💖SuRvIvOrS💖</h4>
-      <ul class="record-list"></ul>
-    </div>
-  </div>
+
 
   <div id="game-screen" class="screen" style="display: none;">
     <div id="game-header-panel">
@@ -329,26 +315,19 @@
                 <h2>Best of the Best</h2>
             </header>
             
-            <div class="hof-records-container">
-                <div class="hof-record-block">
-                    <div class="trophy-icon">🏆</div>
-                    <h3>High Score</h3>
-                    <p class="player-name">PlayerOne</p>
-                    <p class="player-score">999,999</p>
+            <div id="setup-records">
+                <h3>🏆 Los mejores de los mejores / Best of the Best 🏆</h3>
+                <div class="mode-records" data-mode="infinite">
+                    <h4>♾️InFiNiTeRs♾️</h4>
+                    <ul class="record-list"></ul>
                 </div>
-                
-                <div class="hof-record-block">
-                    <div class="trophy-icon">🏆</div>
-                    <h3>Longest Run</h3>
-                    <p class="player-name">PlayerTwo</p>
-                    <p class="player-score">Level 50</p>
+                <div class="mode-records" data-mode="timer">
+                    <h4>⏱DesPaCiToS⏱️</h4>
+                    <ul class="record-list"></ul>
                 </div>
-                
-                <div class="hof-record-block">
-                    <div class="trophy-icon">🏆</div>
-                    <h3>Fastest Victory</h3>
-                    <p class="player-name">PlayerThree</p>
-                    <p class="player-score">01:23:45</p>
+                <div class="mode-records" data-mode="lives">
+                    <h4>💖SuRvIvOrS💖</h4>
+                    <ul class="record-list"></ul>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -996,12 +996,8 @@ function navigateToStep(stepName) {
     const targetIndex = stepsOrder.indexOf(stepName);
     const configFlowScreenDiv = document.getElementById('config-flow-screen'); // Necesaria para .splash-active
     const infoPanel = document.querySelector('.config-info-panel'); // Referencia al panel derecho
-    const recordsSection = document.getElementById('setup-records');
-
-    if (recordsSection) {
-        recordsSection.style.display = stepName === 'splash' ? 'flex' : 'none';
-        if (stepName === 'splash') renderSetupRecords();
-    }
+    // No longer toggle records on the splash screen; records are shown in the
+    // Hall of Fame overlay instead.
 
     allSteps.forEach(stepDiv => {
         const stepIdWithoutSuffix = stepDiv.id.replace('-step', '');
@@ -3787,6 +3783,8 @@ window.addEventListener('resize', () => {
   const hofCloseBtn = document.getElementById('hof-close-btn');
 
   function openHallOfFame() {
+    // Ensure latest records are displayed when opening
+    renderSetupRecords();
     hofOverlay.classList.add('is-visible');
   }
 

--- a/style.css
+++ b/style.css
@@ -1671,6 +1671,7 @@ button:active {
 /* Splash buttons */
 #initial-start-button,
 #settings-button,
+#hall-of-fame-btn,
 #help-button {
   font-family: var(--font-pixel);
   font-size: 1.5em;
@@ -1685,9 +1686,11 @@ button:active {
 
 #initial-start-button:hover,
 #settings-button:hover,
+#hall-of-fame-btn:hover,
 #help-button:hover,
 #initial-start-button.selected,
 #settings-button.selected,
+#hall-of-fame-btn.selected,
 #help-button.selected {
   animation: splash-blink 1s infinite;
   color: #ffffff !important;


### PR DESCRIPTION
## Summary
- style the Hall of Fame button like other splash buttons
- move records section inside the Hall of Fame overlay
- load records when opening Hall of Fame
- remove static placeholder entries
- stop toggling records during step navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68629ff5edb883279222e9f1e31144a2