### PR TITLE
Replace level up flip with shake animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,8 +308,7 @@
         </div>
       </div>
 
-    <div id="level-display" class="level-display" data-old-level="1" data-new-level="1"></div>
-    <div id="level-indicator">Level 1</div>
+    <h2 id="level-text">Level 1 (0/10)</h2>
     <div id="ranking-box"></div>
       <div class="game-footer">
       <span>© 2025 Pablo Torrado, University of Hong Kong. All rights reserved.</span>

--- a/script.js
+++ b/script.js
@@ -28,33 +28,24 @@ window.chuacheReactionsEnabled = true;
 window.defaultVosEnabled = false;
 
 // ---------------- Level Up Visual Effects -----------------
-// Trigger a screen thump and color shockwave when leveling up.
-function triggerLevelUpAnimation(newLevelColor) {
-  const body = document.body;
-  body.style.setProperty('--new-level-color', newLevelColor);
-  body.classList.add('level-up-animation');
+// Trigger a quick screen shake when leveling up.
+function triggerLevelUpShake() {
+  const gameContainer = document.body;
+  gameContainer.classList.remove('level-up-shake');
   setTimeout(() => {
-    body.classList.remove('level-up-animation');
-    body.style.backgroundColor = newLevelColor;
-  }, 1000);
+    gameContainer.classList.add('level-up-shake');
+  }, 10);
 }
 
-// Update the numeric display with a flip animation.
-function updateLevelDisplay(oldNum, newNum) {
-  const container = document.getElementById('level-display');
-  if (!container) return;
-  container.innerHTML = `
-    <div class="flip-card">
-      <div class="top-half-static">${oldNum}</div>
-      <div class="bottom-half-static">${newNum}</div>
-      <div class="top-half-flip">${newNum}</div>
-      <div class="bottom-half-flip">${oldNum}</div>
-    </div>
-  `;
+// Update the level text with a fade transition.
+function updateLevelText(newText) {
+  const levelElement = document.getElementById('level-text');
+  if (!levelElement) return;
+  levelElement.classList.add('is-fading');
   setTimeout(() => {
-    const card = container.querySelector('.flip-card');
-    if (card) card.classList.add('flipped');
-  }, 50);
+    levelElement.innerText = newText;
+    levelElement.classList.remove('is-fading');
+  }, 300);
 }
 
 function saveSetting(key, value) {
@@ -424,11 +415,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     correctAnswersTotal = 0;
     currentLevel = 0;
 
-    const levelIndicator = document.getElementById('level-indicator');
-    if (levelIndicator) {
-      levelIndicator.textContent = 'Level 1';
+    const levelText = document.getElementById('level-text');
+    if (levelText) {
+      levelText.textContent = 'Level 1 (0/10)';
     }
-    updateLevelDisplay(1, 1);
   }
 
   function updateLevelAndVisuals() {
@@ -443,7 +433,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     if (newLevel > currentLevel) {
-      const oldDisplay = currentLevel + 1;
       currentLevel = newLevel;
 
       // Palette for Levels 2 through 8
@@ -462,8 +451,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
       const gameMainPanel = document.getElementById('game-main-panel');
       const chuacheBox = document.getElementById('chuache-box');
-      triggerLevelUpAnimation(newColor);
-      updateLevelDisplay(oldDisplay, currentLevel + 1);
+      triggerLevelUpShake();
+      updateLevelText(`Level ${currentLevel + 1} (0/10)`);
+      document.body.style.backgroundColor = newColor;
       if (gameMainPanel) {
         gameMainPanel.style.backgroundColor = newColor;
       }
@@ -474,15 +464,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function updateProgressUI() {
-    const levelIndicator = document.getElementById('level-indicator');
-    if (!levelIndicator) return;
+    const levelText = document.getElementById('level-text');
+    if (!levelText) return;
 
-    const timeMode = selectedGameMode === 'timer';
     const goal = 10;
     const progress = correctAnswersTotal % goal;
 
     const newText = `Level ${currentLevel + 1} (${progress}/${goal})`;
-    levelIndicator.textContent = newText;
+    updateLevelText(newText);
   }
   let totalPlayedSeconds = 0;
   let totalQuestions = 0;           

--- a/style.css
+++ b/style.css
@@ -152,94 +152,38 @@
 :-----------------------------------------------------------------------------:
 */
 
-@keyframes screen-thump {
-  0% { transform: translateY(0); }
-  25% { transform: translateY(15px); }
-  50% { transform: translateY(-10px); }
-  75% { transform: translateY(5px); }
-  100% { transform: translateY(0); }
+/* A more aggressive and chaotic screen shake keyframe */
+@keyframes strong-shake {
+  0% { transform: translate(0, 0) rotate(0); }
+  10% { transform: translate(-5px, -8px) rotate(-1deg); }
+  20% { transform: translate(5px, 8px) rotate(1deg); }
+  30% { transform: translate(-8px, 5px) rotate(0deg); }
+  40% { transform: translate(8px, -5px) rotate(1deg); }
+  50% { transform: translate(-5px, 8px) rotate(-1deg); }
+  60% { transform: translate(5px, -8px) rotate(0deg); }
+  70% { transform: translate(-8px, -5px) rotate(1deg); }
+  80% { transform: translate(8px, 5px) rotate(-1deg); }
+  90% { transform: translate(-5px, 8px) rotate(0deg); }
+  100% { transform: translate(0, 0) rotate(0); }
 }
 
-@keyframes color-shockwave {
-  from { opacity: 1; transform: scale(0); }
-  to   { opacity: 0; transform: scale(1.5); }
-}
-
-body::after {
-  content: '';
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: radial-gradient(circle, var(--new-level-color, #fff) 80%, transparent 100%);
-  transform: scale(0);
-  z-index: 9998;
-  opacity: 0;
-}
-
-body.level-up-animation main {
-  animation: screen-thump 0.4s ease-in-out forwards;
-}
-
-body.level-up-animation::after {
-  animation: color-shockwave 0.6s cubic-bezier(0.25, 1, 0.5, 1) 0.1s forwards;
+/* Class added to the main container when leveling up */
+.level-up-shake {
+  animation: strong-shake 0.5s cubic-bezier(.36,.07,.19,.97) both;
 }
 
 /*
 :-----------------------------------------------------------------------------:
-:  FLIP-FLAP LEVEL NUMBER
+:  SIMPLIFIED LEVEL TEXT TRANSITION
 :-----------------------------------------------------------------------------:
 */
 
-.level-display {
-  font-family: 'Paytone One', sans-serif;
-  font-size: 8rem;
-  color: white;
-  perspective: 1000px;
+#level-text {
+  transition: opacity 0.3s ease-in-out;
 }
 
-.flip-card {
-  position: relative;
-  width: 120px;
-  height: 1.2em;
-  transform-style: preserve-3d;
-  transition: transform 0.6s;
-}
-
-.flip-card > div {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: 50%;
-  line-height: 1.2em;
-  text-align: center;
-  overflow: hidden;
-  backface-visibility: hidden;
-  background: #333;
-  border-radius: 5px;
-}
-
-.top-half-static { top: 0; }
-.bottom-half-static { top: 50%; line-height: 0; }
-
-.top-half-flip {
-  top: 0;
-  transform-origin: bottom;
-  transform: rotateX(180deg);
-  line-height: 1.2em;
-}
-
-.bottom-half-flip {
-  top: 50%;
-  transform-origin: top;
-  transform: rotateX(0deg);
-  transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
-  line-height: 0;
-}
-
-.flip-card.flipped .bottom-half-flip {
-  transform: rotateX(-180deg);
+#level-text.is-fading {
+  opacity: 0;
 }
 @font-face {
   font-family: 'Schwarzenegger';
@@ -810,7 +754,7 @@ button:active {
   font-size: 1em;
 }
 
-#level-indicator {
+#level-text {
   text-align: center;
   font-size: 1.2em;
   font-weight: bold;


### PR DESCRIPTION
## Summary
- remove flip-card level up animation and replace with strong shake
- use fade transition for level text display
- update level up logic in JS to trigger shake and fade text
- simplify HTML level indicator element

## Testing
- `node -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6862a0174d548327b109f4adff359b8d