### PR TITLE
Fix Hall of Fame visibility, add splash footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,12 @@
                           <button id="settings-button" type="button">Options</button>
                           <button id="hall-of-fame-btn" type="button">Hall of Fame</button>
                     </div>
+                    <div class="splash-footer" style="margin-top: 20px; text-align:center; font-size:0.9rem;">
+                        © 2025 Pablo Torrado —
+                        <a class="feedback-link" href="https://forms.office.com/Pages/ResponsePage.aspx?id=TrX5QnckukG_CXoNKoP_CT6b4ULfjEZOgT4FEg4y3yxUM0g1SkVBUDgyN0E0OFVLTU1MOVk1R004Ry4u" target="_blank" rel="noopener">Feedback</a>
+                        ·
+                        <a class="coffee-link" href="https://buymeacoffee.com/theconjugator" target="_blank" rel="noopener">Apoya al dev</a>
+                    </div>
                 </div>
 
       <div id="mode-step" class="config-step">

--- a/script.js
+++ b/script.js
@@ -980,6 +980,10 @@ function playHeaderIntro() {
 }
 playHeaderIntro();
 function navigateToStep(stepName) {
+    // Ensure Hall of Fame tooltip is hidden outside the splash step
+    if (stepName !== 'splash') {
+        closeHallOfFame();
+    }
     const allSteps = document.querySelectorAll('.config-step');
     const stepsOrder = ['splash', 'mode', 'difficulty', 'details'];
     const targetIndex = stepsOrder.indexOf(stepName);
@@ -3108,6 +3112,8 @@ function fadeOutToMenu(callback) {
 
 
 finalStartGameButton.addEventListener('click', async () => {
+    // Ensure Hall of Fame tooltip is closed when starting a game
+    closeHallOfFame();
     const selTenses = Array.from(
         document.querySelectorAll('#tense-buttons .tense-button.selected')
     ).map(btn => btn.dataset.value);

--- a/style.css
+++ b/style.css
@@ -1497,7 +1497,21 @@ button:active {
   filter: brightness(1.3);
   transition: background-color 0.2s, filter 0.2s;
 }
+.splash-footer .feedback-link {
+  color: var(--accent-color-blue);
+  text-decoration: none;
+  padding: 4px 8px;
+  border: 1px solid var(--accent-color-blue);
+  border-radius: 4px;
+  text-shadow: 0 0 4px rgba(255, 255, 255, 0.9);
+  filter: brightness(1.3);
+  transition: background-color 0.2s, filter 0.2s;
+}
 .game-footer .feedback-link:hover {
+  background-color: rgba(255,255,255,0.1);
+  filter: brightness(1.5);
+}
+.splash-footer .feedback-link:hover {
   background-color: rgba(255,255,255,0.1);
   filter: brightness(1.5);
 }
@@ -1517,10 +1531,26 @@ button:active {
   filter: brightness(1.2);
   transition: box-shadow 0.2s, filter 0.2s;
 }
+.splash-footer .coffee-link {
+  color: #8b0000;
+  text-decoration: none;
+  padding: 4px 8px;
+  border: 1px solid #8b0000;
+  border-radius: 4px;
+  background: linear-gradient(45deg, #d4af37, #fffbcc);
+  box-shadow: 0 0 5px rgba(212, 175, 55, 0.7);
+  text-shadow: 0 0 4px rgba(255, 255, 255, 0.9);
+  filter: brightness(1.2);
+  transition: box-shadow 0.2s, filter 0.2s;
+}
 .game-footer .coffee-link:hover {
 
   box-shadow: 0 0 8px rgba(255, 215, 0, 1);
 
+  filter: brightness(1.3);
+}
+.splash-footer .coffee-link:hover {
+  box-shadow: 0 0 8px rgba(255, 215, 0, 1);
   filter: brightness(1.3);
 }
 #left-bubbles, #right-bubbles {


### PR DESCRIPTION
## Summary
- keep the Hall of Fame overlay hidden when leaving the splash or starting a game
- add feedback/support links to the splash screen
- style splash footer links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862a73d12108327b26eba3d2754a4c1