### PR TITLE
Fix splash footer language

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,10 +97,9 @@
                           <button id="hall-of-fame-btn" type="button">Hall of Fame</button>
                     </div>
                     <div class="splash-footer" style="margin-top: 20px; text-align:center; font-size:0.9rem;">
-                        © 2025 Pablo Torrado —
-                        <a class="feedback-link" href="https://forms.office.com/Pages/ResponsePage.aspx?id=TrX5QnckukG_CXoNKoP_CT6b4ULfjEZOgT4FEg4y3yxUM0g1SkVBUDgyN0E0OFVLTU1MOVk1R004Ry4u" target="_blank" rel="noopener">Feedback</a>
-                        ·
-                        <a class="coffee-link" href="https://buymeacoffee.com/theconjugator" target="_blank" rel="noopener">Apoya al dev</a>
+                        <span>© 2025 Pablo Torrado, University of Hong Kong. All rights reserved.</span>
+                        <a class="feedback-link" href="https://forms.office.com/Pages/ResponsePage.aspx?id=TrX5QnckukG_CXoNKoP_CT6b4ULfjEZOgT4FEg4y3yxUM0g1SkVBUDgyN0E0OFVLTU1MOVk1R004Ry4u" target="_blank" rel="noopener">FEEDBACK! (Bugs and features)</a>
+                        <a class="coffee-link" href="https://buymeacoffee.com/theconjugator" target="_blank" rel="noopener">Support the Game!</a>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- translate Spanish text in the splash footer to English

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863be4992548327afeb963117b1f1e1