### PR TITLE
Implement free clue system

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,8 @@
 
       <div id="bottom-panel">
         <div id="action-buttons">
-          <button id="check-button">Get Clue / Check Answer</button>
+          <button id="check-answer-button">Check Answer</button>
+          <button id="clue-button">Use Clue</button>
           <button id="skip-button">Skip</button>
           <button id="end-button">END GAME</button>
         </div>


### PR DESCRIPTION
## Summary
- split combined clue/check button into Check Answer and Clue buttons
- add `freeClues` state and update clue button text dynamically
- introduce `startLivesMode` and update level progression for free clues
- implement new clue button logic and display function

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863bed83fe08327b16ebfede94bd38c