### PR TITLE
Fix Hall of Fame modal initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -618,6 +618,34 @@ document.addEventListener('DOMContentLoaded', async () => {
   const toggleIgnoreAccentsBtn = document.getElementById('toggle-ignore-accents');
   const titleElement = document.querySelector('.glitch-title');
   const verbTypeLabels = Array.from(document.querySelectorAll('label[data-times]'));
+
+  // --- Hall of Fame Modal Logic ---
+  const hofOverlay = document.getElementById('hof-overlay');
+  const hofCloseBtn = document.querySelector('#hof-overlay .hof-close-btn');
+
+  function openHallOfFame() {
+    if (hofOverlay) {
+      renderSetupRecords();
+      hofOverlay.classList.add('is-visible');
+    }
+  }
+
+  function closeHallOfFame() {
+    if (hofOverlay) {
+      hofOverlay.classList.remove('is-visible');
+    }
+  }
+
+  if (hallOfFameBtn) hallOfFameBtn.addEventListener('click', openHallOfFame);
+  if (gameHallOfFameBtn) gameHallOfFameBtn.addEventListener('click', openHallOfFame);
+  if (hofCloseBtn) hofCloseBtn.addEventListener('click', closeHallOfFame);
+  if (hofOverlay) {
+    hofOverlay.addEventListener('click', (event) => {
+      if (event.target === hofOverlay) {
+        closeHallOfFame();
+      }
+    });
+  }
   
   const container = document.getElementById('verb-buttons');
   // Use a live query so replacing the container element doesn't break references
@@ -3909,32 +3937,6 @@ window.addEventListener('resize', () => {
       const original = coffeeLink.textContent;
       coffeeLink.textContent = 'THANKS!';
       setTimeout(() => { coffeeLink.textContent = original; }, 1500);
-    });
-  }
-
-  // --- Hall of Fame Modal Logic ---
-  const hofOverlay = document.getElementById('hof-overlay');
-  const hofCloseBtn = document.getElementById('hof-close-btn');
-
-  function openHallOfFame() {
-    // Ensure latest records are displayed when opening
-    renderSetupRecords();
-    hofOverlay.classList.add('is-visible');
-  }
-
-  function closeHallOfFame() {
-    hofOverlay.classList.remove('is-visible');
-  }
-
-  if (hallOfFameBtn) hallOfFameBtn.addEventListener('click', openHallOfFame);
-  if (gameHallOfFameBtn) gameHallOfFameBtn.addEventListener('click', openHallOfFame);
-  if (hofCloseBtn) hofCloseBtn.addEventListener('click', closeHallOfFame);
-
-  if (hofOverlay) {
-    hofOverlay.addEventListener('click', (event) => {
-      if (event.target === hofOverlay) {
-        closeHallOfFame();
-      }
     });
   }
 


### PR DESCRIPTION
## Summary
- initialize Hall of Fame modal once DOM is loaded
- use specific selector for close button

## Testing
- `node -e "require('./script.js')" 2>&1 | head` *(fails: Audio is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6863d5b8dcb08327b484696ebb1778d3