### PR TITLE
Fix Hall of Fame overlay visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -640,7 +640,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   const hofCloseBtn = document.querySelector('#hof-overlay .hof-close-btn');
 
   function openHallOfFame() {
-    if (!hofOverlay) return;
+    if (!hofOverlay) {
+      console.warn('Hall of Fame overlay not found');
+      return;
+    }
     try {
       renderSetupRecords();
     } catch (err) {
@@ -649,15 +652,22 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (setupContainer) setupContainer.innerHTML = '<p>No records available.</p>';
     }
     hofOverlay.classList.add('is-visible');
+    console.log('Hall of Fame opened');
   }
 
   function closeHallOfFame() {
     if (hofOverlay) {
       hofOverlay.classList.remove('is-visible');
+      console.log('Hall of Fame closed');
     }
   }
 
-  if (hallOfFameBtn) hallOfFameBtn.addEventListener('click', openHallOfFame);
+  if (hallOfFameBtn) {
+    hallOfFameBtn.addEventListener('click', openHallOfFame);
+    console.log('Hall of Fame button listener attached');
+  } else {
+    console.warn('Hall of Fame button not found');
+  }
   if (hofCloseBtn) hofCloseBtn.addEventListener('click', closeHallOfFame);
   if (hofOverlay) {
     hofOverlay.addEventListener('click', (event) => {

--- a/style.css
+++ b/style.css
@@ -1556,7 +1556,7 @@ button:active {
   top: 0;
   width: 80px;               /* Más estrecho que antes */
   height: 100%;
-  pointer-events: auto;
+  pointer-events: none;       /* Avoid blocking underlying buttons */
   z-index: 1;
 }
 
@@ -1587,8 +1587,8 @@ button:active {
   animation: rise 8s linear forwards;
   opacity: 0.85;
   text-shadow: 1px 1px 2px #000;
-  pointer-events: auto; 
-  image-rendering: pixelated; 
+  pointer-events: none;        /* Decorative bubbles shouldn't intercept clicks */
+  image-rendering: pixelated;
 }
 
 @keyframes rise {


### PR DESCRIPTION
## Summary
- prevent decorative bubbles from intercepting clicks
- add logs around Hall of Fame modal

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68647c340eec8327aa512fe78a177dca