### PR TITLE
Fix hall of fame overlay

### DIFF
--- a/script.js
+++ b/script.js
@@ -640,7 +640,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   const hofCloseBtn = document.querySelector('#hof-overlay .hof-close-btn');
 
   function openHallOfFame() {
-    if (!hofOverlay) return;
+    if (!hofOverlay) {
+      console.warn('Hall of Fame overlay element not found');
+      return;
+    }
+    console.log('Opening Hall of Fame overlay');
     try {
       renderSetupRecords();
     } catch (err) {
@@ -648,16 +652,22 @@ document.addEventListener('DOMContentLoaded', async () => {
       const setupContainer = document.getElementById('setup-records');
       if (setupContainer) setupContainer.innerHTML = '<p>No records available.</p>';
     }
+    hofOverlay.style.display = 'flex';
     hofOverlay.classList.add('is-visible');
   }
 
   function closeHallOfFame() {
     if (hofOverlay) {
+      console.log('Closing Hall of Fame overlay');
       hofOverlay.classList.remove('is-visible');
+      hofOverlay.style.display = 'none';
     }
   }
 
-  if (hallOfFameBtn) hallOfFameBtn.addEventListener('click', openHallOfFame);
+  if (hallOfFameBtn) {
+    console.log('Hall of Fame button listener attached');
+    hallOfFameBtn.addEventListener('click', openHallOfFame);
+  }
   if (hofCloseBtn) hofCloseBtn.addEventListener('click', closeHallOfFame);
   if (hofOverlay) {
     hofOverlay.addEventListener('click', (event) => {

--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@
     z-index: 1000;
 
     /* Center the tooltip */
-    display: flex;
+    display: none; /* hidden until activated */
     justify-content: center;
     align-items: center;
     
@@ -36,6 +36,7 @@
 
 /* Class to show the overlay */
 .hof-overlay.is-visible {
+    display: flex;
     opacity: 1;
     visibility: visible;
 }


### PR DESCRIPTION
## Summary
- keep the hall of fame overlay hidden using `display: none`
- reveal overlay with explicit style changes
- log actions when opening and closing the overlay

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68647c340eec8327aa512fe78a177dca