### PR TITLE
Refactor Hall of Fame overlay visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -651,7 +651,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const setupContainer = document.getElementById('setup-records');
       if (setupContainer) setupContainer.innerHTML = '<p>No records available.</p>';
     }
-    hofOverlay.style.display = 'flex';
+    // Rely solely on CSS class for visibility
     hofOverlay.classList.add('is-visible');
     console.log('Hall of Fame opened');
   }
@@ -660,7 +660,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (hofOverlay) {
       console.log('Closing Hall of Fame overlay');
       hofOverlay.classList.remove('is-visible');
-      hofOverlay.style.display = 'none';
 
     }
 

--- a/style.css
+++ b/style.css
@@ -25,7 +25,7 @@
     z-index: 1100;
 
     /* Center the tooltip */
-    display: none; /* hidden until activated */
+    display: flex; /* Always use flex for centering */
     justify-content: center;
     align-items: center;
     
@@ -37,7 +37,6 @@
 
 /* Class to show the overlay */
 .hof-overlay.is-visible {
-    display: flex;
     opacity: 1;
     visibility: visible;
 }


### PR DESCRIPTION
## Summary
- rely solely on CSS class to toggle Hall of Fame overlay
- adjust CSS so the overlay is always flex and toggled by opacity/visibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686486deb67c8327b8a4d7b79e1386b8