### PR TITLE
Add Hall of Fame modal listeners

### DIFF
--- a/script.js
+++ b/script.js
@@ -623,9 +623,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   const feedback     = document.getElementById('feedback-message');
   const settingsButton = document.getElementById('settings-button');
   const hallOfFameBtn = document.getElementById('hall-of-fame-btn');
+  const hallOfFameNewBtn = document.getElementById('hall-of-fame-new-btn');
   const closeSettingsModalBtn = document.getElementById('close-settings-modal-btn');
   const settingsModal = document.getElementById('settings-modal');
   const settingsBackdrop = document.getElementById('settings-modal-backdrop');
+  const hofModal = document.getElementById('hof-modal');
+  const hofBackdrop = document.getElementById('hof-modal-backdrop');
+  const closeHofModalBtn = document.getElementById('close-hof-modal-btn');
   const musicVolumeSlider = document.getElementById('music-volume-slider');
   const sfxVolumeSlider = document.getElementById('sfx-volume-slider');
   const muteAllButton = document.getElementById('mute-all-button');
@@ -695,6 +699,22 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
     if (closeSettingsModalBtn) closeSettingsModalBtn.addEventListener('click', closeFn);
     settingsBackdrop.addEventListener('click', closeFn);
+  }
+
+  if (hallOfFameNewBtn && hofModal && hofBackdrop) {
+    hallOfFameNewBtn.addEventListener('click', () => {
+      renderSetupRecords();
+      hofModal.style.display = 'block';
+      hofBackdrop.style.display = 'block';
+    });
+
+    const closeHofFn = () => {
+      hofModal.style.display = 'none';
+      hofBackdrop.style.display = 'none';
+    };
+
+    if (closeHofModalBtn) closeHofModalBtn.addEventListener('click', closeHofFn);
+    hofBackdrop.addEventListener('click', closeHofFn);
   }
 
   if (musicVolumeSlider) {

--- a/style.css
+++ b/style.css
@@ -81,6 +81,10 @@
 }
 
 /* Header Text */
+.hof-header {
+    text-align: center;
+    margin-bottom: 20px;
+}
 .hof-header h1 {
     font-family: 'Paytone One', sans-serif; /* Use a dramatic font */
     font-size: 2.5rem;
@@ -1047,6 +1051,9 @@ button:active {
   flex-wrap: wrap;    /* permite que el h3 ocupe la primera “fila” */
   gap: 20px;
   margin-top: 20px;
+  justify-content: center;
+  max-height: calc(100% - 60px);
+  overflow-y: auto;
 }
 
 


### PR DESCRIPTION
## Summary
- wire up `hall-of-fame-new-btn` modal open/close logic
- style Hall of Fame header and records for modal usage

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864884948ec832793278bf89a468b35