### PR TITLE
Fix level 8 transition animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -4056,3 +4056,9 @@ body.iridescent-level {
   animation: iridescent-dark-flow 15s ease infinite;
   background-size: 400% 400%; /* Ensures smooth transition */
 }
+
+body.iridescent-level.level-up-shake {
+  animation: iridescent-dark-flow 15s ease infinite,
+             strong-shake 0.5s cubic-bezier(.36,.07,.19,.97) both;
+  background-size: 400% 400%;
+}


### PR DESCRIPTION
## Summary
- keep the screen shake when level 8 activates the iridescent background

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68649a99bad08327a2bdbd9e16f3850b