### PR TITLE
Add score preview box before starting game

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,8 +144,6 @@
       </div>
 
       <div id="details-step" class="config-step">
-        <button id="final-start-game-button" class="start-button" data-text="Start Game">Start Game</button>
-        <button id="back-button" style="display: none;">Back</button>
         <h3>Customize Your Game:</h3>
         <div id="filter-bar-container">
           <div class="filter-bar">
@@ -215,6 +213,11 @@
           <p><strong>☠️Verb Irregularities☠️</strong></p>
           <div id="verb-type-buttons" class="verb-type-selector"></div>
         </div>
+        <div id="score-preview-box" class="score-preview">
+          Puntos por acierto: <span id="score-preview-value">...</span>
+        </div>
+        <button id="final-start-game-button" class="start-button" data-text="Start Game">Start Game</button>
+        <button id="back-button" style="display: none;">Back</button>
       </div>
 
     </div>

--- a/script.js
+++ b/script.js
@@ -884,6 +884,7 @@ const confirmDifficultyButton = document.getElementById('confirm-difficulty-butt
 const detailsConfigStep = document.getElementById('details-config-step');
 const finalStartGameButton = document.getElementById('final-start-game-button');
 const backButton = document.getElementById('back-button');
+const scorePreviewValue = document.getElementById('score-preview-value');
 
 const infoPanelTitle = document.getElementById('info-panel-title');
 const infoPanelContent = document.getElementById('info-panel-content');
@@ -1296,6 +1297,7 @@ function navigateToStep(stepName) {
         } else if (stepName === 'details') {
             updateInfoPanelContent('Customize Your Game', `<p> <strong><span class="math-inline">\</strong\> </strong>.<br>Adjust tenses, verbs, pronouns, and other options.</p>`);
             checkFinalStartButtonState();
+            updateScorePreview();
         }
     }
 }
@@ -3500,6 +3502,44 @@ function checkFinalStartButtonState() {
     } else if (조건) {
         finalStartGameButton.title = "";
     }
+}
+
+function updateScorePreview() {
+    if (!scorePreviewValue) return;
+
+    let basePoints = 10;
+    if (selectedDifficulty === 'receptive') {
+        basePoints = 5;
+    } else if (selectedDifficulty === 'productive') {
+        basePoints = 15;
+    }
+
+    const selectedTensesCount = document.querySelectorAll('#tense-buttons .tense-button.selected').length;
+    const tenseBonus = (selectedTensesCount > 0) ? (selectedTensesCount - 1) * 2 : 0;
+
+    const selectedPronounsCount = document.querySelectorAll('#pronoun-buttons .pronoun-group-button.selected').length;
+    const selectedVerbsCount = document.querySelectorAll('#verb-buttons .verb-button.selected').length;
+
+    const pronounBonusValue = 0.5;
+    const verbBonusValue = 0.1;
+
+    const pronounBonus = (selectedPronounsCount > 1) ? (selectedPronounsCount - 1) * pronounBonusValue : 0;
+    const verbBonus = (selectedVerbsCount > 1) ? (selectedVerbsCount - 1) * verbBonusValue : 0;
+
+    const ignoreAccentsBtn = document.getElementById('toggle-ignore-accents');
+    const accentBonus = (ignoreAccentsBtn && !ignoreAccentsBtn.classList.contains('selected')) ? 8 : 0;
+
+    const totalPoints = basePoints + tenseBonus + pronounBonus + verbBonus + accentBonus;
+    scorePreviewValue.textContent = totalPoints.toFixed(1);
+}
+
+const filterBar = document.getElementById('filter-bar-container');
+if (filterBar) {
+    filterBar.addEventListener('click', () => setTimeout(updateScorePreview, 50));
+}
+const irregularitiesContainer = document.getElementById('verb-irregularities-container');
+if (irregularitiesContainer) {
+    irregularitiesContainer.addEventListener('click', () => setTimeout(updateScorePreview, 50));
 }
 	document.getElementById('tense-buttons').addEventListener('click', checkFinalStartButtonState);
 	document.getElementById('verb-buttons').addEventListener('click', checkFinalStartButtonState);

--- a/style.css
+++ b/style.css
@@ -4062,3 +4062,24 @@ body.iridescent-level.level-up-shake {
              strong-shake 0.5s cubic-bezier(.36,.07,.19,.97) both;
   background-size: 400% 400%;
 }
+
+/* --- Score Preview Box Styles --- */
+.score-preview {
+    background-color: #1a2a1a;
+    color: #f39c12;
+    border: 2px dashed #f39c12;
+    border-radius: 8px;
+    padding: 12px 18px;
+    margin-top: 20px;
+    margin-bottom: 15px;
+    text-align: center;
+    font-family: 'PixelSerif', sans-serif;
+    font-size: 1.1em;
+    text-shadow: 1px 1px #000;
+    transition: all 0.3s ease;
+}
+#score-preview-value {
+    font-size: 1.3em;
+    margin-left: 8px;
+    color: #ffffff;
+}


### PR DESCRIPTION
## Summary
- show a new "score preview" box in the game setup
- style the preview box
- compute previewed score dynamically based on current configuration

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864a08221688327b19b6c1f7cb45889