### PR TITLE
Move start buttons before settings and update English text

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,8 @@
       </div>
 
       <div id="details-step" class="config-step">
+        <button id="final-start-game-button" class="start-button" data-text="Start Game">Start Game</button>
+        <button id="back-button" style="display: none;">Back</button>
         <h3>Customize Your Game:</h3>
         <div id="filter-bar-container">
           <div class="filter-bar">
@@ -214,10 +216,8 @@
           <div id="verb-type-buttons" class="verb-type-selector"></div>
         </div>
         <div id="score-preview-box" class="score-preview">
-          Puntos por acierto: <span id="score-preview-value">...</span>
+          Points scored per verb: <span id="score-preview-value">...</span>
         </div>
-        <button id="final-start-game-button" class="start-button" data-text="Start Game">Start Game</button>
-        <button id="back-button" style="display: none;">Back</button>
       </div>
 
     </div>


### PR DESCRIPTION
## Summary
- reorder `Start Game` and `Back` buttons to appear above the "Customize Your Game" heading
- change score preview label to English

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864a4d9ad6483278816a20c4ff97a79