### PR TITLE
Move Hall of Fame into options

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
       <fieldset>
           <legend>Miscellaneous</legend>
           <button id="reset-settings-button">Reset All Settings</button>
+            <button id="hall-of-fame-btn" type="button">Options / Hall of Fame</button>
       </fieldset>
 
     </div>
@@ -94,9 +95,6 @@
                         <button id="initial-start-button">Start Game</button>
                     <div style="text-align: center; margin-top: 20px;">
                           <button id="settings-button" type="button">Options</button>
-                    </div>
-                    <div style="text-align: center; margin-top: 10px;">
-                          <button id="hall-of-fame-btn" type="button">Hall of Fame</button>
                     </div>
                     <div class="splash-footer" style="margin-top: 20px; text-align:center; font-size:0.9rem;">
                         <span>© 2025 Pablo Torrado, University of Hong Kong. All rights reserved.</span><br><br>

--- a/style.css
+++ b/style.css
@@ -1652,7 +1652,6 @@ button:active {
 /* Splash buttons */
 #initial-start-button,
 #settings-button,
-#hall-of-fame-btn,
 #help-button {
   font-family: var(--font-pixel);
   font-size: 1.5em;
@@ -1667,11 +1666,9 @@ button:active {
 
 #initial-start-button:hover,
 #settings-button:hover,
-#hall-of-fame-btn:hover,
 #help-button:hover,
 #initial-start-button.selected,
 #settings-button.selected,
-#hall-of-fame-btn.selected,
 #help-button.selected {
   animation: splash-blink 1s infinite;
   color: #ffffff !important;


### PR DESCRIPTION
## Summary
- integrate Hall of Fame button inside Options modal and rename to "Options / Hall of Fame"
- remove Hall of Fame from splash buttons style

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6864a576440c8327a3bcf8fecb807240