### PR TITLE
Fix Hall of Fame overlay visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -661,8 +661,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       const setupContainer = document.getElementById('setup-records');
       if (setupContainer) setupContainer.innerHTML = '<p>No records available.</p>';
     }
-    // Rely solely on CSS class for visibility
+    // Ensure overlay is visible even if some style disabled it
+    hofOverlay.style.display = 'flex';
+    // force reflow so transition applies
+    void hofOverlay.offsetWidth;
     hofOverlay.classList.add('is-visible');
+    document.body.classList.add('tooltip-open-no-scroll');
     console.log('Hall of Fame opened');
   }
 
@@ -670,6 +674,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (hofOverlay) {
       console.log('Closing Hall of Fame overlay');
       hofOverlay.classList.remove('is-visible');
+      const cleanup = () => {
+        hofOverlay.style.display = 'none';
+        hofOverlay.removeEventListener('transitionend', cleanup);
+      };
+      hofOverlay.addEventListener('transitionend', cleanup);
+      document.body.classList.remove('tooltip-open-no-scroll');
 
     }
 

--- a/style.css
+++ b/style.css
@@ -15,6 +15,7 @@
 
 /* The main overlay - full screen, hidden by default */
 .hof-overlay {
+    display: none; /* Hidden by default */
     position: fixed;
     top: 0;
     left: 0;
@@ -25,10 +26,9 @@
     z-index: 1100;
 
     /* Center the tooltip */
-    display: flex; /* Always use flex for centering */
     justify-content: center;
     align-items: center;
-    
+
     /* Hide/show transition */
     opacity: 0;
     visibility: hidden;
@@ -37,6 +37,9 @@
 
 /* Class to show the overlay */
 .hof-overlay.is-visible {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     opacity: 1;
     visibility: visible;
 }


### PR DESCRIPTION
## Summary
- ensure the Hall of Fame overlay displays correctly
- hide overlay by default and show on demand

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864b47089588327ad1c7786d09f0e58