### PR TITLE
Fix Hall of Fame overlay toggling

### DIFF
--- a/script.js
+++ b/script.js
@@ -652,6 +652,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   function openHallOfFame() {
     if (!hofOverlay) return;
+    if (hofOverlay.classList.contains('is-visible')) {
+      return;
+    }
     console.log('Opening Hall of Fame overlay');
 
     try {


### PR DESCRIPTION
## Summary
- avoid triggering the Hall of Fame overlay if it is already visible

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6864bd4ef1c48327837cdebce7be0308