### PR TITLE
Fix decimals in score formula

### DIFF
--- a/script.js
+++ b/script.js
@@ -2944,12 +2944,14 @@ function checkAnswer() {
     // ----------------------------------------------------
     multiplier = 1 + 0.1 * streak;
 
-    const pts = Math.round(basePoints * multiplier * bonus)
-                          + accentBonus
-                          + irregularBonus
-                          + reflexiveBonus
-                          + pronounBonus
-                          + verbBonus;
+    const pts = Math.round(
+      basePoints * multiplier * bonus +
+      accentBonus +
+      irregularBonus +
+      reflexiveBonus +
+      pronounBonus +
+      verbBonus
+    );
 	
     score += pts;
     let feedbackText = `✅<br><span class="feedback-time">Time: ${rt.toFixed(1)}s ×${bonus.toFixed(1)}</span>`;
@@ -3712,7 +3714,7 @@ function updateScorePreview() {
     const accentBonus = (ignoreAccentsBtn && !ignoreAccentsBtn.classList.contains('selected')) ? 8 : 0;
 
     const totalPoints = basePoints + tenseBonus + pronounBonus + verbBonus + accentBonus;
-    scorePreviewValue.textContent = totalPoints.toFixed(1);
+    scorePreviewValue.textContent = Math.round(totalPoints);
 }
 
 const filterBar = document.getElementById('filter-bar-container');


### PR DESCRIPTION
## Summary
- round total points to ensure scores are integers
- remove decimals from score preview

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6865062b606083278f38e6394a6620ea