### PR TITLE
Update Hall of Fame section

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,12 +95,6 @@
                     <div style="text-align: center; margin-top: 20px;">
                           <button id="settings-button" type="button">Options</button>
                     </div>
-                    <div style="text-align: center; margin-top: 10px;">
-                          <button id="salon-button" type="button">Salón</button>
-                    </div>
-                    <div style="text-align: center; margin-top: 10px;">
-                          <button id="hall-of-fame-btn" type="button">Hall of Fame</button>
-                    </div>
                     <div class="splash-footer" style="margin-top: 20px; text-align:center; font-size:0.9rem;">
                         <span>© 2025 Pablo Torrado, University of Hong Kong. All rights reserved.</span><br><br>
                         <a class="feedback-link" href="https://forms.office.com/Pages/ResponsePage.aspx?id=TrX5QnckukG_CXoNKoP_CT6b4ULfjEZOgT4FEg4y3yxUM0g1SkVBUDgyN0E0OFVLTU1MOVk1R004Ry4u" target="_blank" rel="noopener">FEEDBACK! (Bugs and features)</a>
@@ -109,8 +103,7 @@
 
                     <div id="splash-records-box">
                         <header class="hof-header">
-                            <h1>Salón de la Fama</h1>
-                            <h2>Records</h2>
+                            <h1>Hall of Fame</h1>
                         </header>
                         <div id="records-display-container"></div>
                     </div>
@@ -336,11 +329,11 @@
             <div id="setup-records">
                 <h3>🏆 Los mejores de los mejores / Best of the Best 🏆</h3>
                 <div class="mode-records" data-mode="timer">
-                    <h4>⏱DesPaCiToS⏱️</h4>
+                    <h4>Time Attack ⏱️</h4>
                     <ul class="record-list"></ul>
                 </div>
                 <div class="mode-records" data-mode="lives">
-                    <h4>💖SuRvIvOrS💖</h4>
+                    <h4>Survival</h4>
                     <ul class="record-list"></ul>
                 </div>
             </div>
@@ -364,8 +357,7 @@
       <div class="hof-tooltip">
           <button id="salon-close-btn" class="hof-close-btn">&times;</button>
           <header class="hof-header">
-              <h1>Salón de la Fama</h1>
-              <h2>Records</h2>
+              <h1>Hall of Fame</h1>
           </header>
           <div class="hof-records-container" id="salon-records-container">
           </div>

--- a/script.js
+++ b/script.js
@@ -678,8 +678,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     let content = '';
 
     for (const mode of modes) {
-      const modeTitle = mode === 'timer' ? 'Contrarreloj' : 'Supervivencia';
-      let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>Modo ${modeTitle}</h3>\n                    <ul class="record-list">`;
+      const modeTitle = mode === 'timer' ? 'Time Attack' : 'Survival';
+      let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>Mode ${modeTitle}</h3>\n                    <ul class="record-list">`;
 
       try {
         if (typeof supabase === 'undefined') throw new Error('Supabase client not defined.');
@@ -779,8 +779,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       let content = '';
 
       for (const mode of modes) {
-          const modeTitle = mode === 'timer' ? 'Contrarreloj' : 'Supervivencia';
-          let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>Modo ${modeTitle}</h3>\n                    <ul class="record-list">`;
+          const modeTitle = mode === 'timer' ? 'Time Attack' : 'Survival';
+          let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>Mode ${modeTitle}</h3>\n                    <ul class="record-list">`;
 
           try {
               const { data, error } = await supabase

--- a/style.css
+++ b/style.css
@@ -89,14 +89,14 @@
     margin-bottom: 20px;
 }
 .hof-header h1 {
-    font-family: 'Paytone One', sans-serif; /* Use a dramatic font */
+    font-family: var(--font-pixel);
     font-size: 2.5rem;
     color: #ffffff;
     margin: 0;
     text-transform: uppercase;
 }
 .hof-header h2 {
-    font-family: sans-serif;
+    font-family: var(--font-pixel);
     font-size: 1.2rem;
     color: #f39c12;
     margin-top: 5px;
@@ -118,6 +118,7 @@
     border-radius: 15px;
     flex: 1;
     border: 1px solid rgba(243, 156, 18, 0.3);
+    text-align: left;
 }
 
 .hof-record-block .trophy-icon {
@@ -126,7 +127,7 @@
 }
 
 .hof-record-block h3 {
-    font-family: 'Paytone One', sans-serif;
+    font-family: var(--font-pixel);
     color: #f39c12;
     font-size: 1.5rem;
     margin-bottom: 15px;
@@ -1078,6 +1079,7 @@ button:active {
   letter-spacing: 0.05em;
   text-shadow: 2px 2px #111; /* Sombra sutil para darle profundidad */
   font-size: 0.85em;
+  text-align: left;
 }
 
 /* Opcional: fondo distinto por modo */


### PR DESCRIPTION
## Summary
- remove old Hall of Fame and Salón buttons from splash screen
- rename "Salón de la Fama" sections to "Hall of Fame"
- left-align record lists and use game font
- display timer and survival mode names in English

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686506e03880832791dfdda1eded824a