### PR TITLE
Fix CRT scanline layout issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body class="is-loading">
+  <div id="app-wrapper">
   <div id="specific-modal-backdrop" class="specific-modal-backdrop" style="display:none;"></div>
   <div id="specific-info-modal" class="specific-modal" style="display:none;">
     <div class="specific-modal-content">
@@ -371,6 +372,7 @@
           </div>
       </div>
   </div>
+</div>
 </body>
 </html>
 

--- a/style.css
+++ b/style.css
@@ -243,28 +243,18 @@
 }
 
 body {
-  font-family: var(--font-pixel);
-  background-color: var(--bg-color);
-  color: var(--text-color);
-  max-width: 800px;
-  margin: 20px auto;
-  padding: 20px;
-  padding-bottom: 20px; /* espacio inferior */
-  font-size: 20px;
-  image-rendering: pixelated;
-  image-rendering: -moz-crisp-edges;
-  image-rendering: crisp-edges;
-  text-shadow: 1px 2px #111;
-  border-radius: 20px;
-  box-shadow:
-    inset 0 0 60px rgba(0, 255, 128, 0.1),
-    inset 0 0 200px rgba(0, 255, 128, 0.05),
-    0 0 60px rgba(0, 255, 128, 0.2);
-  /* Preparar contenedor para efectos tipo CRT */
-  position: relative;
-  overflow-x: hidden;
-  overflow-y: auto;
-  
+  font-family: 'VT323', monospace;
+  color: #00FF41;
+  background-color: #0d0d0d;
+  overflow: hidden; /* This MUST stay on the body */
+  margin: 0;
+}
+
+#app-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
 }
 
 body::before {
@@ -1253,6 +1243,8 @@ button:active {
     width: 100%;
     max-width: 100%;
     font-size: 17px;
+  }
+  #app-wrapper {
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
## Summary
- wrap all body content in `#app-wrapper`
- apply flexbox layout styles to `#app-wrapper`
- simplify `body` styles and keep overflow hidden
- update mobile styles so flexbox rules apply to `#app-wrapper`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68650808133c8327a31abb86503b0597