### PR TITLE
Improve record display and mode names

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,11 +113,11 @@
         <h3>Select Game Mode:</h3>
         <div id="game-modes-container">
           <button class="mode-button config-flow-button provisional-selection" data-mode="timer" data-infokey="timerMode">
-            Time Attack ⏱️
+            Time Attackers⏱️🧨
             <span class="context-info-icon" data-info-key="timerMode"></span>
           </button>
           <button class="mode-button config-flow-button" data-mode="lives" data-infokey="livesMode">
-            Survival
+            Survivalistas ❤️‍🩹
             <span class="context-info-icon" data-info-key="livesMode"></span>
           </button>
           <button class="mode-button config-flow-button" data-mode="study" data-infokey="studyMode">
@@ -329,11 +329,11 @@
             <div id="setup-records">
                 <h3>🏆 Los mejores de los mejores / Best of the Best 🏆</h3>
                 <div class="mode-records" data-mode="timer">
-                    <h4>Time Attack ⏱️</h4>
+                    <h4>Time Attackers⏱️🧨</h4>
                     <ul class="record-list"></ul>
                 </div>
                 <div class="mode-records" data-mode="lives">
-                    <h4>Survival</h4>
+                    <h4>Survivalistas ❤️‍🩹</h4>
                     <ul class="record-list"></ul>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -678,7 +678,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let content = '';
 
     for (const mode of modes) {
-      const modeTitle = mode === 'timer' ? 'Time Attack' : 'Survival';
+      const modeTitle = mode === 'timer' ? 'Time Attackers⏱️🧨' : 'Survivalistas ❤️‍🩹';
       let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>Mode ${modeTitle}</h3>\n                    <ul class="record-list">`;
 
       try {
@@ -695,9 +695,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         if (data && data.length > 0) {
           data.forEach((record, i) => {
-            const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '';
-            const levelInfo = record.level ? ` (Nivel ${record.level})` : '';
-            recordsHtml += `<li><div class="record-item"><span class="medal">${medal}</span><strong>${record.name}:</strong> ${record.score} pts${levelInfo}</div></li>`;
+      const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '';
+      const levelInfo = record.level ? ` - lvl. ${record.level}` : '';
+      recordsHtml += `<li><div class="record-item"><span class="medal">${medal}</span><strong>${record.name}:</strong> ${record.score}${levelInfo}</div></li>`;
           });
         } else {
           recordsHtml += '<li>A\xFAn no hay r\xE9cords.</li>';
@@ -779,7 +779,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       let content = '';
 
       for (const mode of modes) {
-          const modeTitle = mode === 'timer' ? 'Time Attack' : 'Survival';
+        const modeTitle = mode === 'timer' ? 'Time Attackers⏱️🧨' : 'Survivalistas ❤️‍🩹';
           let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>Mode ${modeTitle}</h3>\n                    <ul class="record-list">`;
 
           try {
@@ -794,9 +794,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
               if (data && data.length > 0) {
                   data.forEach((record, i) => {
-                      const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '';
-                      const levelInfo = record.level ? ` (Nivel ${record.level})` : '';
-                      recordsHtml += `<li><div class="record-item"><span class="medal">${medal}</span><strong>${record.name}:</strong> ${record.score} pts${levelInfo}</div></li>`;
+                    const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '';
+                    const levelInfo = record.level ? ` - lvl. ${record.level}` : '';
+                    recordsHtml += `<li><div class="record-item"><span class="medal">${medal}</span><strong>${record.name}:</strong> ${record.score}${levelInfo}</div></li>`;
                   });
               } else {
                   recordsHtml += '<li>A\xFAn no hay r\xE9cords.</li>';
@@ -2248,11 +2248,11 @@ async function renderSetupRecords() {
         const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '';
         const levelInfo =
           (mode === 'timer' || mode === 'lives') && record.level
-            ? ` lv${record.level}`
+            ? ` - lvl. ${record.level}`
             : '';
         const li = document.createElement('li');
         li.innerHTML =
-          `<div class="record-item"><span class="medal">${medal}</span><strong>${record.name}:</strong> ${record.score} pts${levelInfo}</div>`;
+          `<div class="record-item"><span class="medal">${medal}</span><strong>${record.name}:</strong> ${record.score}${levelInfo}</div>`;
         ul.appendChild(li);
       });
     });
@@ -2284,11 +2284,11 @@ async function renderSetupRecords() {
       data.forEach((record, i) => {
         const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '';
         const li = document.createElement('li');
-        const levelInfo = (mode === 'timer' || mode === 'lives') && record.level ? ` lv${record.level}` : '';
+        const levelInfo = (mode === 'timer' || mode === 'lives') && record.level ? ` - lvl. ${record.level}` : '';
         li.innerHTML = `
           <div class="record-item">
             <span class="medal">${medal}</span>
-            <strong>${record.name}:</strong> ${record.score} pts${levelInfo}
+            <strong>${record.name}:</strong> ${record.score}${levelInfo}
           </div>`;
         ul.appendChild(li);
       });
@@ -3982,8 +3982,8 @@ function openNameModal(message, callback) {
 
 function updateGameTitle() {
   const modeLabels = {
-    'timer':      'Time Attack ⏱️',
-    'lives':      'Survival',
+    'timer':      'Time Attackers⏱️🧨',
+    'lives':      'Survivalistas ❤️‍🩹',
     'receptive':  '💭ReCall: Easy (Spanish to English)💭',
     'productive_easy': '⚙️ConjugaATE: Normal (Spanish to Spanish)⚙️',
     'productive': '⌨️Pr0duc€: Difficult (English to Spanish)⌨️'

--- a/style.css
+++ b/style.css
@@ -115,6 +115,7 @@
 .hof-record-block {
     background-color: rgba(0, 0, 0, 0.2);
     padding: 25px;
+    padding-left: 10px;
     border-radius: 15px;
     flex: 1;
     border: 1px solid rgba(243, 156, 18, 0.3);
@@ -140,7 +141,7 @@
 }
 
 .hof-record-block .player-score {
-    font-size: 1.1rem;
+    font-size: 1rem;
     color: #bdc3c7;
     margin: 5px 0 0 0;
 }
@@ -1074,11 +1075,12 @@ button:active {
   flex: 1;                   /* ocupan partes iguales */
   background-color: #f4f4f4; /* un gris clarito */
   padding: 15px;
+  padding-left: 5px;
   border-radius: 8px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.1);
   letter-spacing: 0.05em;
   text-shadow: 2px 2px #111; /* Sombra sutil para darle profundidad */
-  font-size: 0.85em;
+  font-size: 0.8em;
   text-align: left;
 }
 


### PR DESCRIPTION
## Summary
- update game mode text to *Time Attackers* and *Survivalistas*
- tweak hall of fame record layout and font sizes
- show level as `- lvl. X` without `pts`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68650b885cf88327b4e00a4b012aea66