### PR TITLE
Fix splash text styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,7 +48,7 @@
 .hof-tooltip {
     position: relative;
     background: linear-gradient(145deg, #2c3e50, #1a2533); /* Dark, stylish gradient */
-    color: #ecf0f1;
+    color: #ffffff;
     padding: 40px 50px;
     border-radius: 20px;
     border: 2px solid #f39c12; /* Gold border */
@@ -73,7 +73,7 @@
     right: 20px;
     background: none;
     border: none;
-    color: #ecf0f1;
+    color: #ffffff;
     font-size: 2.5rem;
     cursor: pointer;
     transition: transform 0.2s ease, color 0.2s ease;
@@ -1501,7 +1501,7 @@ button:active {
   padding: 10px 0;
 }
 .game-footer .feedback-link {
-  color: var(--accent-color-blue);
+  color: #ffffff;
   text-decoration: none;
   padding: 4px 8px;
   border: 1px solid var(--accent-color-blue);
@@ -1511,7 +1511,7 @@ button:active {
   transition: background-color 0.2s, filter 0.2s;
 }
 .splash-footer .feedback-link {
-  color: var(--accent-color-blue);
+  color: #ffffff;
   text-decoration: none;
   padding: 4px 8px;
   border: 1px solid var(--accent-color-blue);
@@ -1531,7 +1531,7 @@ button:active {
 
 /* Buy Me a Coffee button */
 .game-footer .coffee-link {
-  color: #8b0000; /* dark red text for contrast */
+  color: #ffffff; /* dark red text for contrast */
   text-decoration: none;
   padding: 4px 8px;
   border: 1px solid #8b0000; /* matching dark red border */
@@ -1545,7 +1545,7 @@ button:active {
   transition: box-shadow 0.2s, filter 0.2s;
 }
 .splash-footer .coffee-link {
-  color: #8b0000;
+  color: #ffffff;
   text-decoration: none;
   padding: 4px 8px;
   border: 1px solid #8b0000;
@@ -1665,7 +1665,7 @@ button:active {
   font-family: var(--font-pixel);
   font-size: 1.5em;
   background-color: transparent !important;
-  color: #335533 !important;
+  color: #ffffff !important;
   border: none !important;
   box-shadow: none !important;
   padding: 10px 18px;
@@ -4133,14 +4133,14 @@ body.iridescent-level.level-up-shake {
 /* --- Splash Screen Text Color Overrides --- */
 #splash-step .splash-footer span,
 #splash-step .splash-footer a {
-    color: #39FF14 !important;
+    color: #ffffff !important;
 }
 
 #splash-records-box .hof-header h1 {
-    color: #39FF14;
+    color: #ffffff;
 }
 
 #splash-records-box .record-item,
 #splash-records-box .record-item strong {
-    color: #39FF14;
+    color: #ffffff;
 }


### PR DESCRIPTION
## Summary
- make Hall of Fame tooltip text pure white
- revert splash footer to white text
- revert Hall of Fame button color to white
- set feedback & support buttons to white text

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68651b5abec08327b7b8b847579cb8b7