### PR TITLE
Rename game modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,15 +113,15 @@
         <h3>Select Game Mode:</h3>
         <div id="game-modes-container">
           <button class="mode-button config-flow-button provisional-selection" data-mode="timer" data-infokey="timerMode">
-            Time Attackers⏱️🧨
+            ⏱️ Time attack ⏱️
             <span class="context-info-icon" data-info-key="timerMode"></span>
           </button>
           <button class="mode-button config-flow-button" data-mode="lives" data-infokey="livesMode">
-            Survivalistas ❤️‍🩹
+            ❤️‍🩹 Survival ❤️‍🩹
             <span class="context-info-icon" data-info-key="livesMode"></span>
           </button>
           <button class="mode-button config-flow-button" data-mode="study" data-infokey="studyMode">
-            📚 Study Mode
+            📚 Study Mode ✏️
             <span class="context-info-icon" data-info-key="studyMode"></span>
           </button>
         </div>

--- a/script.js
+++ b/script.js
@@ -678,7 +678,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     let content = '';
 
     for (const mode of modes) {
-      const modeTitle = mode === 'timer' ? 'Time Attackers⏱️🧨' : 'Survivalistas ❤️‍🩹';
+      const modeTitle = mode === 'timer' ? '⏱️ Time attack ⏱️' : '❤️‍🩹 Survival ❤️‍🩹';
       let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>${modeTitle}</h3>\n                    <ul class="record-list">`;
 
       try {
@@ -778,9 +778,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       const modes = ['timer', 'lives'];
       let content = '';
 
-      for (const mode of modes) {
-        const modeTitle = mode === 'timer' ? 'Time Attackers⏱️🧨' : 'Survivalistas ❤️‍🩹';
-          let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>${modeTitle}</h3>\n                    <ul class="record-list">`;
+    for (const mode of modes) {
+      const modeTitle = mode === 'timer' ? '⏱️ Time attack ⏱️' : '❤️‍🩹 Survival ❤️‍🩹';
+      let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>${modeTitle}</h3>\n                    <ul class="record-list">`;
 
           try {
               const { data, error } = await supabase
@@ -3982,8 +3982,9 @@ function openNameModal(message, callback) {
 
 function updateGameTitle() {
   const modeLabels = {
-    'timer':      'Time Attackers⏱️🧨',
-    'lives':      'Survivalistas ❤️‍🩹',
+    'timer':      '⏱️ Time attack ⏱️',
+    'lives':      '❤️‍🩹 Survival ❤️‍🩹',
+    'study':      '📚 Study Mode ✏️',
     'receptive':  '💭ReCall: Easy (Spanish to English)💭',
     'productive_easy': '⚙️ConjugaATE: Normal (Spanish to Spanish)⚙️',
     'productive': '⌨️Pr0duc€: Difficult (English to Spanish)⌨️'

--- a/style.css
+++ b/style.css
@@ -3774,7 +3774,7 @@ td.irregular-highlight {
   /* El #bottom-panel fluirá naturalmente debajo de #game-layout, no necesita cambios aquí. */
 }
 
-/* --- Lives Mode Visual Tweaks --- */
+/* --- Survival Mode Visual Tweaks --- */
 #lives-mechanics-display {
   display: flex;
   justify-content: center;

--- a/tooltips.js
+++ b/tooltips.js
@@ -1,6 +1,6 @@
 const specificInfoData = {
   timerMode: {
-    title: "⏱️ Timer Mode (4 Minutes)",
+    title: "⏱️ Time attack ⏱️ (4 Minutes)",
     html: `You have <strong>4 minutes</strong> to score as many points as possible.<br>
            <strong class="modal-subtitle">Time Mechanics:</strong><br>
            - Start with 4:00 minutes.<br>
@@ -19,7 +19,7 @@ const specificInfoData = {
            <strong class="modal-subtitle">Goal:</strong> Maximize your score before time runs out!`
   },
   livesMode: {
-    title: "💖 Lives Mode",
+    title: "❤️‍🩹 Survival ❤️‍🩹",
     html: `Survive as long as you can! You start with <strong>5 lives</strong> (❤️).<br>
            Each incorrect or skipped answer costs one life.<br><br>
            <strong class="modal-subtitle">Gaining Extra Lives:</strong><br>
@@ -35,7 +35,7 @@ const specificInfoData = {
           <strong class="modal-subtitle">Goal:</strong> Stay alive and get the highest score!`
   },
   studyMode: {
-    title: "📚 Study Mode",
+    title: "📚 Study Mode ✏️",
     html: `<p>A minimalist mode for focused practice without distractions.</p>
          <strong class="modal-subtitle">Features:</strong>
          <ul>
@@ -73,7 +73,7 @@ const specificInfoData = {
            <div class="typing-animation-container"><div class="typing-animation" id="conjugate-example-anim"></div></div>
            <strong>Base Points:</strong> <span class="points-value">+10</span> per correct answer.<br>
            <span class="points-value">+2</span> for each extra tense selected.<br>
-           <strong class="emphasis-mechanic">💖 Lives Mode Bonus:</strong> When playing in "Lives Mode", irregular or reflexive verbs in "Conjugate" have a <span class="emphasis-mechanic">~1 in 30</span> chance of being a 🎁 Prize Verb for an extra life!`
+           <strong class="emphasis-mechanic">❤️‍🩹 Survival Bonus:</strong> When playing in "Survival Mode", irregular or reflexive verbs in "Conjugate" have a <span class="emphasis-mechanic">~1 in 30</span> chance of being a 🎁 Prize Verb for an extra life!`
   },
   productiveConfig: {
     title: "⌨️ Produce Mode",
@@ -88,7 +88,7 @@ const specificInfoData = {
            <div class="typing-animation-container"><div class="typing-animation" id="produce-example-anim"></div></div>
            <strong>Base Points:</strong> <span class="points-value">+15</span> per correct answer.<br>
            <span class="points-value">+2</span> for each extra tense selected.<br>
-          <strong class="emphasis-mechanic">💖 Lives Mode Bonus:</strong> When playing in "Lives Mode", irregular or reflexive verbs in "Produce" have a <span class="emphasis-mechanic">~1 in 20</span> chance of being a 🎁 Prize Verb for an extra life!`
+          <strong class="emphasis-mechanic">❤️‍🩹 Survival Bonus:</strong> When playing in "Survival Mode", irregular or reflexive verbs in "Produce" have a <span class="emphasis-mechanic">~1 in 20</span> chance of being a 🎁 Prize Verb for an extra life!`
   },
   accentHelp: {
     title: "Ignore Accents",


### PR DESCRIPTION
## Summary
- update names for game mode buttons
- update mode labels and scoreboard displays
- rename modes in tooltip data
- adjust comments for survival mode visuals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d4dafbbc8327a1c1e4a0a7352f18