### PR TITLE
Update Hall of Fame record section labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,11 +329,11 @@
             <div id="setup-records">
                 <h3>🏆 Los mejores de los mejores / Best of the Best 🏆</h3>
                 <div class="mode-records" data-mode="timer">
-                    <h4>Time Attackers⏱️🧨</h4>
+                    <h4 class="record-mode-title">Time Attackers ⏱️🧨</h4>
                     <ul class="record-list"></ul>
                 </div>
                 <div class="mode-records" data-mode="lives">
-                    <h4>Survivalistas ❤️‍🩹</h4>
+                    <h4 class="record-mode-title">Sulvivalistas ❤️‍🩹</h4>
                     <ul class="record-list"></ul>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -678,8 +678,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     let content = '';
 
     for (const mode of modes) {
-      const modeTitle = mode === 'timer' ? '⏱️ Time attack ⏱️' : '❤️‍🩹 Survival ❤️‍🩹';
-      let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>${modeTitle}</h3>\n                    <ul class="record-list">`;
+      const modeTitle = mode === 'timer' ? 'Time Attackers ⏱️🧨' : 'Sulvivalistas ❤️‍🩹';
+      let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3 class="record-mode-title">${modeTitle}</h3>\n                    <ul class="record-list">`;
 
       try {
         if (typeof supabase === 'undefined') throw new Error('Supabase client not defined.');
@@ -779,8 +779,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       let content = '';
 
     for (const mode of modes) {
-      const modeTitle = mode === 'timer' ? '⏱️ Time attack ⏱️' : '❤️‍🩹 Survival ❤️‍🩹';
-      let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3>${modeTitle}</h3>\n                    <ul class="record-list">`;
+      const modeTitle = mode === 'timer' ? 'Time Attackers ⏱️🧨' : 'Sulvivalistas ❤️‍🩹';
+      let recordsHtml = `\n                <div class="hof-record-block" data-mode="${mode}">\n                    <h3 class="record-mode-title">${modeTitle}</h3>\n                    <ul class="record-list">`;
 
           try {
               const { data, error } = await supabase

--- a/style.css
+++ b/style.css
@@ -1084,6 +1084,15 @@ button:active {
   text-align: left;
 }
 
+/* Titulo de cada modalidad de record */
+.record-mode-title {
+  font-family: var(--font-pixel);
+  color: var(--title-color);
+  font-size: 1.1em;
+  margin: 0 0 10px;
+  text-shadow: 2px 2px #000;
+}
+
 /* Opcional: fondo distinto por modo */
 .mode-records[data-mode="timer"]    { background-color: #ee3c30; }
 .mode-records[data-mode="lives"]    { background-color: #0b5ac8; }


### PR DESCRIPTION
## Summary
- rename record categories to `Time Attackers ⏱️🧨` and `Sulvivalistas ❤️‍🩹`
- add a CSS class `record-mode-title` for category titles
- apply new class in scripts when rendering records

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d786d7988327bc42fb6aaa68a2c8