### PR TITLE
Reduce Hall of Fame header font size

### DIFF
--- a/style.css
+++ b/style.css
@@ -90,10 +90,10 @@
 }
 .hof-header h1 {
     font-family: var(--font-pixel);
-    font-size: 2.5rem;
+    font-size: 1.25rem;
     color: #ffffff;
     margin: 0;
-    text-transform: uppercase;
+    text-transform: none;
 }
 .hof-header h2 {
     font-family: var(--font-pixel);


### PR DESCRIPTION
## Summary
- ensure Hall of Fame header uses sentence case
- halve font size so the text fits on one line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865de39323c8327bb811d8c0ee15612