### PR TITLE
Remove emojis from score display

### DIFF
--- a/script.js
+++ b/script.js
@@ -2498,8 +2498,8 @@ function applyIrregularityAndTenseFiltersToVerbList() {
     if (selectedGameMode === 'study') return;
 
     scoreDisplay.innerHTML =
-      `<strong>🎯 Score:</strong> ${score}`
-      + `  <strong>🔥 Streak:</strong> ${streak}`
+      `<strong>Score:</strong> ${score}`
+      + ` | <strong>Streak:</strong> ${streak}`
       + ` = <strong>×${multiplier.toFixed(1)}</strong>`;
     
     const maxStreakForFullFire = 15;


### PR DESCRIPTION
## Summary
- clean up score display text by removing emojis from the `Score` and `Streak` labels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865e749c3dc8327b8b17d100076497c