### PR TITLE
Tighten spacing around game HUD

### DIFF
--- a/style.css
+++ b/style.css
@@ -671,10 +671,10 @@ button:active {
 
 #question-prompt {
   font-size: 1.35em; /* Slightly smaller question text */
-  margin-bottom: 25px;
+  margin-bottom: 15px;
   color: var(--title-color);
   background-color: var(--input-bg); /* Fondo oscuro para la pregunta */
-  padding: 15px;
+  padding: 10px;
   border: 1px solid var(--border-color);
   min-height: 30px; /* Asegurar altura mínima */
   text-align: center;
@@ -738,7 +738,7 @@ button:active {
   align-items: center;
   justify-content: center;
   line-height: 1.4; /* Improve line spacing for multiline messages */
-  margin-top: 10px;
+  margin-top: 8px;
 }
 #feedback-fixed { margin-bottom: 4px; }
 #feedback-area:empty { /* Ocultar borde si está vacío */
@@ -2239,8 +2239,8 @@ button:active {
   display: flex;
   justify-content: center;   /* centrado horizontal */
   align-items: center;       /* alineado vertical */
-  gap: 16px;                 /* separación entre cajas */
-  margin: 16px auto;         /* separación vertical + centrado del contenedor */
+  gap: 8px;                  /* separación entre cajas */
+  margin: 8px auto;          /* separación vertical + centrado del contenedor */
 }
 
 /* Barra superior con mecánicas de juego */
@@ -3478,7 +3478,7 @@ td.irregular-highlight {
   display: flex;
   justify-content: center;
   width: 100%;
-  margin-top: 15px; /* Añade espacio entre la pregunta y la caja de respuesta */
+  margin-top: 8px; /* Espacio más reducido con la pregunta */
 }
 
 #chuache-box {
@@ -3659,7 +3659,7 @@ td.irregular-highlight {
 /* --- New Bottom Panel occupying full width --- */
 #bottom-panel {
     width: 100%;
-    margin-top: 20px;
+    margin-top: 10px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -3744,8 +3744,8 @@ td.irregular-highlight {
 /* --- Estilo del Nuevo Panel Inferior Independiente --- */
 #bottom-panel {
   width: 100%;
-  margin-top: 20px;
-  padding-top: 15px;
+  margin-top: 10px;
+  padding-top: 10px;
   border-top: 2px dashed var(--border-color); /* Separador visual */
   display: flex;
   flex-direction: column;
@@ -3937,8 +3937,8 @@ td.irregular-highlight {
 #game-header-panel, #bottom-panel {
     background-color: rgba(0, 0, 0, 0.2);
     border-radius: 8px;
-    padding: 15px;
-    margin-bottom: 20px;
+    padding: 10px;
+    margin-bottom: 10px;
     box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
 }
 
@@ -3974,7 +3974,7 @@ td.irregular-highlight {
     color: var(--title-color);
     font-weight: bold;
     text-shadow: 2px 2px 4px rgba(0,0,0,0.5);
-    margin-bottom: 10px;
+    margin-bottom: 5px;
 }
 
 #answer-area input[type="text"] {


### PR DESCRIPTION
## Summary
- compress the timer layout
- tighten question prompt, answer row, and feedback area gaps
- trim padding and margins on bottom panels

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68708b9fdc948327acfcbbfb81035c21