### PR TITLE
Reduce spacing on game screen

### DIFF
--- a/style.css
+++ b/style.css
@@ -738,7 +738,7 @@ button:active {
   align-items: center;
   justify-content: center;
   line-height: 1.4; /* Improve line spacing for multiline messages */
-  margin-top: 8px;
+  margin-top: 4px;
 }
 #feedback-fixed { margin-bottom: 4px; }
 #feedback-area:empty { /* Ocultar borde si está vacío */
@@ -1005,7 +1005,7 @@ button:active {
 #feedback-area,
 #score-container,
 #ranking-box {
-  margin: 0 auto 20px;     /* margen automático a los lados, 20px abajo */
+  margin: 0 auto 10px;     /* margen automático a los lados, menor espacio abajo */
 }
 
 #question-prompt {
@@ -1014,7 +1014,7 @@ button:active {
 #input-es-container,
 #input-en-container {
   width: 80%;
-  margin: 0 auto 15px;
+  margin: 0 auto 8px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2239,19 +2239,19 @@ button:active {
   display: flex;
   justify-content: center;   /* centrado horizontal */
   align-items: center;       /* alineado vertical */
-  gap: 8px;                  /* separación entre cajas */
-  margin: 8px auto;          /* separación vertical + centrado del contenedor */
+  gap: 4px;                  /* separación entre cajas reducida */
+  margin: 4px auto;          /* menor espacio vertical */
 }
 
 /* Barra superior con mecánicas de juego */
 #game-mechanics-bar {
   width: 100%;
-  margin-bottom: 8px; /* Espacio antes del tablero de juego */
-  padding: 10px 0;
+  margin-bottom: 4px; /* Espacio antes del tablero de juego reducido */
+  padding: 6px 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 20px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
@@ -3478,7 +3478,7 @@ td.irregular-highlight {
   display: flex;
   justify-content: center;
   width: 100%;
-  margin-top: 8px; /* Espacio más reducido con la pregunta */
+  margin-top: 4px; /* Espacio más reducido con la pregunta */
 }
 
 #chuache-box {
@@ -3659,7 +3659,7 @@ td.irregular-highlight {
 /* --- New Bottom Panel occupying full width --- */
 #bottom-panel {
     width: 100%;
-    margin-top: 10px;
+    margin-top: 5px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -3937,8 +3937,8 @@ td.irregular-highlight {
 #game-header-panel, #bottom-panel {
     background-color: rgba(0, 0, 0, 0.2);
     border-radius: 8px;
-    padding: 10px;
-    margin-bottom: 10px;
+    padding: 6px;
+    margin-bottom: 6px;
     box-shadow: inset 0 0 10px rgba(0,0,0,0.5);
 }
 
@@ -3974,7 +3974,7 @@ td.irregular-highlight {
     color: var(--title-color);
     font-weight: bold;
     text-shadow: 2px 2px 4px rgba(0,0,0,0.5);
-    margin-bottom: 5px;
+    margin-bottom: 3px;
 }
 
 #answer-area input[type="text"] {
@@ -4047,11 +4047,11 @@ td.irregular-highlight {
     }
 
     #question-area { order: 1; }
-    #answer-row { order: 2; margin-top: 5px; }
-    #feedback-area { order: 3; margin-top: 8px; }
+    #answer-row { order: 2; margin-top: 4px; }
+    #feedback-area { order: 3; margin-top: 4px; }
 
     #bottom-panel {
-        margin-top: 8px;
+        margin-top: 5px;
         padding-top: 5px;
     }
 }


### PR DESCRIPTION
## Summary
- tighten vertical padding and margins around the timer, question prompt, input row, and feedback box
- adjust bottom panel spacing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687091ccfa208327b567100f6b59cf1b