### PR TITLE
Improve feedback streak messaging

### DIFF
--- a/script.js
+++ b/script.js
@@ -2990,6 +2990,7 @@ function checkAnswer() {
 	
     score += pts;
     let feedbackText = `✅<br><span class="feedback-time">Time: ${rt.toFixed(1)}s ×${bonus.toFixed(1)}</span>`;
+    feedbackText += `<br><span class="feedback-streak">🔥x${multiplier.toFixed(1)}</span>`;
     if (accentBonus > 0) {
        feedbackText += ` +${accentBonus} accent bonus!`; 
     }

--- a/style.css
+++ b/style.css
@@ -3151,6 +3151,7 @@ body,
 .points-value { color: #FFF176; font-weight: bold; } /* Amarillo */
 .feedback-time { color: #90CAF9; }
 .feedback-points { color: #FFF176; }
+.feedback-streak { color: #FFB74D; }
 .text-red { color: #E57373; }
 .text-green { color: #81C784; }
 .modal-subtitle { /* Nueva clase para subtítulos como "Goal:", "Time Mechanics:" */


### PR DESCRIPTION
## Summary
- show streak multiplier in feedback
- style streak multiplier in orange

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6870cdee0d008327b622d80dbe2c0a40