### PR TITLE
Display total score in level bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,7 @@
 
   <div id="game-screen" class="screen" style="display: none;">
     <div id="game-header-panel">
-      <h2 id="level-text">Level 1 (0/10)</h2>
+      <h2 id="level-text">Level 1 (0/10) | Total Score: 0</h2>
       <h2 id="game-title"></h2>
       <div id="game-mechanics-bar">
         <div id="lives-mechanics-display" style="display: none; text-align: center; margin-bottom: 15px;">

--- a/script.js
+++ b/script.js
@@ -583,7 +583,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const levelText = document.getElementById('level-text');
     if (levelText) {
       const goal = selectedGameMode === 'lives' ? LEVEL_GOAL_LIVES : LEVEL_GOAL_TIMER;
-      levelText.textContent = `Level 1 (0/${goal})`;
+      levelText.textContent = `Level 1 (0/${goal}) | Total Score: ${score}`;
     }
   }
 
@@ -625,7 +625,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       triggerLevelUpShake();
       playFromStart(soundLevelUp);
       const goal = livesMode ? LEVEL_GOAL_LIVES : LEVEL_GOAL_TIMER;
-      updateLevelText(`Level ${currentLevel + 1} (0/${goal})`);
+      updateLevelText(`Level ${currentLevel + 1} (0/${goal}) | Total Score: ${score}`);
       document.body.style.backgroundColor = newBodyColor;
       if (gameMainPanel) gameMainPanel.style.backgroundColor = newPanelColor;
       if (gameHeaderPanel) gameHeaderPanel.style.backgroundColor = newPanelColor;
@@ -644,7 +644,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const goal = selectedGameMode === 'lives' ? LEVEL_GOAL_LIVES : LEVEL_GOAL_TIMER;
     const progress = correctAnswersTotal % goal;
 
-    const newText = `Level ${currentLevel + 1} (${progress}/${goal})`;
+    const newText = `Level ${currentLevel + 1} (${progress}/${goal}) | Total Score: ${score}`;
     updateLevelText(newText);
   }
   let totalPlayedSeconds = 0;


### PR DESCRIPTION
## Summary
- add total score text in level header
- keep score visible on level resets and progress updates

## Testing
- `node -e "const fs=require('fs'); new Function(fs.readFileSync('script.js','utf8')); console.log('Syntax OK');"`

------
https://chatgpt.com/codex/tasks/task_e_6870d0062d648327b9ae44882c9341ca