### PR TITLE
Fix streak bar animation trigger

### DIFF
--- a/script.js
+++ b/script.js
@@ -2553,6 +2553,7 @@ function applyIrregularityAndTenseFiltersToVerbList() {
     }
     */
     updateProgressUI();
+    updateStreakBar();
   }
 
 let usedVerbs = [];  


### PR DESCRIPTION
## Summary
- ensure `updateStreakBar()` runs when the score updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870dabeecc88327836898768e29cb16