### PR TITLE
Adjust streak bar visuals

### DIFF
--- a/script.js
+++ b/script.js
@@ -2526,7 +2526,7 @@ function applyIrregularityAndTenseFiltersToVerbList() {
 
     const maxStreak = 10;
     const containerHeight = streakBar.clientHeight;
-    const flameHeight = containerHeight / 2;
+    const flameHeight = containerHeight * 0.45;
     const streakRatio = Math.min(streak / maxStreak, 1);
 
     streakFireEl.style.height = `${flameHeight}px`;
@@ -3507,7 +3507,7 @@ function quitToSettings() {
   // Add this block to reset the fire animation
   const streakFireEl = document.getElementById('streak-fire');
   if (streakFireEl) {
-    streakFireEl.style.bottom = '-50%';
+    streakFireEl.style.bottom = '-60%';
   }
 
   // Restore header character visibility for the next game

--- a/style.css
+++ b/style.css
@@ -4183,7 +4183,7 @@ body.iridescent-level.level-up-shake {
 #streak-bar {
   position: relative;
   width: 50px;
-  height: 350px; /* Adjust height to fit your layout */
+  height: 298px; /* Reduced by 15% */
   background-color: #1a1a1a;
   border: 2px solid var(--border-color);
   border-radius: 15px; /* Curved borders */
@@ -4193,10 +4193,10 @@ body.iridescent-level.level-up-shake {
 
 #streak-fire {
   position: absolute;
-  bottom: -50%;
+  bottom: -60%;
   left: 0;
   width: 100%;
-  height: 50%;
+  height: 45%;
   background-color: transparent;
 
   transition: bottom 0.3s ease-out;


### PR DESCRIPTION
## Summary
- tune streak bar size to 298px height
- start the streak fire 10% lower and smaller
- tweak streak bar animation reset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870e580b0b48327a42061c41d798115