### PR TITLE
Fix fire effect clipping

### DIFF
--- a/style.css
+++ b/style.css
@@ -771,7 +771,7 @@ button:active {
 
 #streak-bar {
   position: absolute;
-  right: 10px; /* move slightly left so fire isn't cut off */
+  right: 30px; /* move slightly left so fire isn't cut off */
   bottom: 0;
   z-index: 1;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- adjust `#streak-bar` right offset to keep fire effect visible

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687453ed34a883278b8bf237a17c5aae