### PR TITLE
Adjust streak fire container width

### DIFF
--- a/style.css
+++ b/style.css
@@ -4081,7 +4081,7 @@ body.iridescent-level.level-up-shake {
 /* 1. Add styles for the new container */
 .fire-bar-container {
   position: relative;
-  width: 40px;
+  width: 70px; /* Increased from 40px to allow full streak animation */
   height: 180px;
   /* Make container invisible so only the fire is visible */
   background-color: transparent;


### PR DESCRIPTION
## Summary
- widen the streak fire container so the effect isn't cut off

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68750df076748327a8aadfc706ddf933