### PR TITLE
Remove unused padding from main game panel

### DIFF
--- a/style.css
+++ b/style.css
@@ -3564,8 +3564,7 @@ td.irregular-highlight {
   display: flex;
   flex-direction: column;
   gap: 10px;
-
-  padding-right: 25px;
+  /* padding-right has been removed */
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- clean up `#game-main` styles by dropping unnecessary `padding-right`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875174ef04c8327bd94e559a9fd597a