### PR TITLE
Update feedback message formatting

### DIFF
--- a/script.js
+++ b/script.js
@@ -3008,7 +3008,7 @@ correct = possibleCorrectAnswers.includes(ans);
     );
 
     score += pts;
-    let feedbackText = `✅<br><span class="feedback-time">⏱️${rt.toFixed(1)}s ×${bonus.toFixed(1)}</span> |<span class="feedback-streak">${streak}🔥x${multiplier.toFixed(1)}</span>`;
+    let feedbackText = `✅<span class="feedback-time">⏱️${rt.toFixed(1)}s ×${bonus.toFixed(1)}</span> + <span class="feedback-streak">${streak} streak x${multiplier.toFixed(1)}</span>`;
     if (accentBonus > 0) {
        feedbackText += ` +${accentBonus} accent bonus!`; 
     }


### PR DESCRIPTION
## Summary
- tweak script.js so success feedback uses `+` instead of `|` and keeps same colors

## Testing
- `npx eslint script.js` *(fails: no such command)*


------
https://chatgpt.com/codex/tasks/task_e_6875184e5a688327956ec99636b90c4a