### PR TITLE
Fix Spanish input alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -975,6 +975,11 @@ button:active {
   gap: 10px;
 }
 
+#input-es-container {
+  position: relative;
+  left: 10px; /* slight right shift to center under question */
+}
+
 #answer-area button,
 #game-modes .mode-button {
   display: inline-block;
@@ -3664,6 +3669,10 @@ td.irregular-highlight {
     flex-direction: column;
     align-items: center;
     gap: 5px;
+  }
+  #input-es-container {
+    position: relative;
+    left: 10px; /* match desktop offset */
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust Spanish answer input container to line up under question text

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687519f586b8832799ec5feac8ae784e