### PR TITLE
Reduce width of Spanish conjugation bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -966,7 +966,7 @@ button:active {
 }
 #input-es-container,
 #input-en-container {
-  width: 80%;
+  width: 75%;
   margin: 0 auto 8px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- shrink Spanish conjugation input bar width from 80% to 75%

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6875266804c483278769622e5898587b